### PR TITLE
fix(langchain): Record reasoning tokens as metric

### DIFF
--- a/.changeset/langchain-reasoning-tokens-metric.md
+++ b/.changeset/langchain-reasoning-tokens-metric.md
@@ -1,5 +1,0 @@
----
-"braintrust": patch
----
-
-fix(langchain): Record reasoning tokens as metric

--- a/.changeset/langchain-reasoning-tokens-metric.md
+++ b/.changeset/langchain-reasoning-tokens-metric.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix(langchain): Record reasoning tokens as metric

--- a/e2e/scenarios/langgraph-auto-instrumentation/__cassettes__/langgraph-v1-latest.cassette.json
+++ b/e2e/scenarios/langgraph-auto-instrumentation/__cassettes__/langgraph-v1-latest.cassette.json
@@ -4,21 +4,20 @@
       "callIndex": 0,
       "id": "66fa29eed4a03d8d",
       "matchKey": "POST api.openai.com/v1/chat/completions",
-      "recordedAt": "2026-08-13T03:26:58.345Z",
+      "recordedAt": "2026-08-24T12:42:31.291Z",
       "request": {
         "body": {
           "kind": "json",
           "value": {
-            "max_tokens": 24,
+            "max_completion_tokens": 4000,
             "messages": [
               {
                 "content": "Reply with exactly: hello from langgraph",
                 "role": "user"
               }
             ],
-            "model": "gpt-4o-mini-2024-07-18",
-            "stream": false,
-            "temperature": 0
+            "model": "gpt-5-nano",
+            "stream": false
           }
         },
         "headers": {},
@@ -33,7 +32,6 @@
               {
                 "finish_reason": "stop",
                 "index": 0,
-                "logprobs": null,
                 "message": {
                   "annotations": [],
                   "content": "hello from langgraph",
@@ -42,26 +40,26 @@
                 }
               }
             ],
-            "created": 1786591617,
-            "id": "chatcmpl-ECGNl5cq4BBzVI8ggfknC0vEAu2E5",
-            "model": "gpt-4o-mini-2024-07-18",
+            "created": 1787575349,
+            "id": "chatcmpl-EGOIPr0SW9oyOHO2N8Jy5UDSV3YBe",
+            "model": "gpt-5-nano-2025-08-07",
             "object": "chat.completion",
             "service_tier": "default",
-            "system_fingerprint": "fp_c400bf5046",
+            "system_fingerprint": null,
             "usage": {
-              "completion_tokens": 4,
+              "completion_tokens": 205,
               "completion_tokens_details": {
                 "accepted_prediction_tokens": 0,
                 "audio_tokens": 0,
-                "reasoning_tokens": 0,
+                "reasoning_tokens": 192,
                 "rejected_prediction_tokens": 0
               },
-              "prompt_tokens": 15,
+              "prompt_tokens": 14,
               "prompt_tokens_details": {
                 "audio_tokens": 0,
                 "cached_tokens": 0
               },
-              "total_tokens": 19
+              "total_tokens": 219
             }
           }
         },
@@ -69,13 +67,13 @@
           "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
           "alt-svc": "h3=\":443\"; ma=86400",
           "cf-cache-status": "DYNAMIC",
-          "cf-ray": "a2a49f0acbe84d75-IAD",
+          "cf-ray": "a3026fee5c78d6b9-IAD",
           "connection": "keep-alive",
           "content-encoding": "gzip",
           "content-type": "application/json",
-          "date": "Thu, 13 Aug 2026 03:26:58 GMT",
+          "date": "Mon, 24 Aug 2026 12:42:31 GMT",
           "openai-organization": "braintrust-data",
-          "openai-processing-ms": "541",
+          "openai-processing-ms": "1609",
           "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
           "openai-version": "2020-10-01",
           "server": "cloudflare",
@@ -85,12 +83,12 @@
           "x-content-type-options": "nosniff",
           "x-openai-proxy-wasm": "v0.1",
           "x-ratelimit-limit-requests": "30000",
-          "x-ratelimit-limit-tokens": "150000000",
+          "x-ratelimit-limit-tokens": "180000000",
           "x-ratelimit-remaining-requests": "29999",
-          "x-ratelimit-remaining-tokens": "149999987",
+          "x-ratelimit-remaining-tokens": "179999988",
           "x-ratelimit-reset-requests": "2ms",
           "x-ratelimit-reset-tokens": "0s",
-          "x-request-id": "req_dc282d2f30e94331925848868f636a64"
+          "x-request-id": "req_9cf25b259fe045088420df5f87ef64c1"
         },
         "status": 200,
         "statusText": "OK"

--- a/e2e/scenarios/langgraph-auto-instrumentation/__cassettes__/langgraph-v1.cassette.json
+++ b/e2e/scenarios/langgraph-auto-instrumentation/__cassettes__/langgraph-v1.cassette.json
@@ -4,21 +4,20 @@
       "callIndex": 0,
       "id": "66fa29eed4a03d8d",
       "matchKey": "POST api.openai.com/v1/chat/completions",
-      "recordedAt": "2026-08-13T03:26:56.239Z",
+      "recordedAt": "2026-08-24T12:42:27.921Z",
       "request": {
         "body": {
           "kind": "json",
           "value": {
-            "max_tokens": 24,
+            "max_completion_tokens": 4000,
             "messages": [
               {
                 "content": "Reply with exactly: hello from langgraph",
                 "role": "user"
               }
             ],
-            "model": "gpt-4o-mini-2024-07-18",
-            "stream": false,
-            "temperature": 0
+            "model": "gpt-5-nano",
+            "stream": false
           }
         },
         "headers": {},
@@ -33,7 +32,6 @@
               {
                 "finish_reason": "stop",
                 "index": 0,
-                "logprobs": null,
                 "message": {
                   "annotations": [],
                   "content": "hello from langgraph",
@@ -42,26 +40,26 @@
                 }
               }
             ],
-            "created": 1786591615,
-            "id": "chatcmpl-ECGNjtLhzIrCEXYX3GAGMFYYZYTvC",
-            "model": "gpt-4o-mini-2024-07-18",
+            "created": 1787575346,
+            "id": "chatcmpl-EGOIMT8aiC5hHSG3SUYm2IwtKcvUn",
+            "model": "gpt-5-nano-2025-08-07",
             "object": "chat.completion",
             "service_tier": "default",
-            "system_fingerprint": "fp_c400bf5046",
+            "system_fingerprint": null,
             "usage": {
-              "completion_tokens": 4,
+              "completion_tokens": 141,
               "completion_tokens_details": {
                 "accepted_prediction_tokens": 0,
                 "audio_tokens": 0,
-                "reasoning_tokens": 0,
+                "reasoning_tokens": 128,
                 "rejected_prediction_tokens": 0
               },
-              "prompt_tokens": 15,
+              "prompt_tokens": 14,
               "prompt_tokens_details": {
                 "audio_tokens": 0,
                 "cached_tokens": 0
               },
-              "total_tokens": 19
+              "total_tokens": 155
             }
           }
         },
@@ -69,13 +67,13 @@
           "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
           "alt-svc": "h3=\":443\"; ma=86400",
           "cf-cache-status": "DYNAMIC",
-          "cf-ray": "a2a49efddbd14d75-IAD",
+          "cf-ray": "a3026fd97f94d6b9-IAD",
           "connection": "keep-alive",
           "content-encoding": "gzip",
           "content-type": "application/json",
-          "date": "Thu, 13 Aug 2026 03:26:56 GMT",
+          "date": "Mon, 24 Aug 2026 12:42:27 GMT",
           "openai-organization": "braintrust-data",
-          "openai-processing-ms": "431",
+          "openai-processing-ms": "1464",
           "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
           "openai-version": "2020-10-01",
           "server": "cloudflare",
@@ -85,12 +83,12 @@
           "x-content-type-options": "nosniff",
           "x-openai-proxy-wasm": "v0.1",
           "x-ratelimit-limit-requests": "30000",
-          "x-ratelimit-limit-tokens": "150000000",
+          "x-ratelimit-limit-tokens": "180000000",
           "x-ratelimit-remaining-requests": "29999",
-          "x-ratelimit-remaining-tokens": "149999987",
+          "x-ratelimit-remaining-tokens": "179999988",
           "x-ratelimit-reset-requests": "2ms",
           "x-ratelimit-reset-tokens": "0s",
-          "x-request-id": "req_950c8bce5e8a4c2c98ce6134fe7404ff"
+          "x-request-id": "req_dae493e1576040cba3891ea64b841ee0"
         },
         "status": 200,
         "statusText": "OK"

--- a/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1-latest.log-payloads.json
+++ b/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1-latest.log-payloads.json
@@ -266,6 +266,7 @@
       "tags": []
     },
     "metrics": {
+      "completion_reasoning_tokens": "<number>",
       "completion_tokens": "<number>",
       "end": 0,
       "prompt_cached_tokens": "<number>",

--- a/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1-latest.log-payloads.json
+++ b/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1-latest.log-payloads.json
@@ -208,10 +208,9 @@
         "sdk_language": "javascript"
       },
       "invocation_params": {
-        "max_tokens": 24,
-        "model": "gpt-4o-mini-2024-07-18",
-        "stream": false,
-        "temperature": 0
+        "max_completion_tokens": 4000,
+        "model": "gpt-5-nano",
+        "stream": false
       },
       "metadata": {
         "checkpoint_ns": "sayHello:<uuid:9>",
@@ -225,17 +224,15 @@
         "langgraph_triggers": [
           "branch:to:sayHello"
         ],
-        "ls_max_tokens": 24,
-        "ls_model_name": "gpt-4o-mini-2024-07-18",
+        "ls_model_name": "gpt-5-nano",
         "ls_model_type": "chat",
         "ls_provider": "openai",
-        "ls_temperature": 0,
         "versions": {
           "@langchain/core": "<langchain-version>",
           "@langchain/openai": "<langchain-version>"
         }
       },
-      "model": "gpt-4o-mini-2024-07-18",
+      "model": "gpt-5-nano-2025-08-07",
       "options": {
         "signal": {}
       },
@@ -249,16 +246,15 @@
           "ChatOpenAI"
         ],
         "kwargs": {
-          "max_tokens": 24,
-          "model": "gpt-4o-mini-2024-07-18",
+          "max_tokens": 4000,
+          "model": "gpt-5-nano",
           "openai_api_key": {
             "id": [
               "OPENAI_API_KEY"
             ],
             "lc": 1,
             "type": "secret"
-          },
-          "temperature": 0
+          }
         },
         "lc": 1,
         "type": "constructor"
@@ -294,28 +290,12 @@
                 "invalid_tool_calls": [],
                 "response_metadata": {
                   "finish_reason": "stop",
-                  "model_name": "gpt-4o-mini-2024-07-18",
+                  "model_name": "gpt-5-nano-2025-08-07",
                   "model_provider": "openai",
-                  "system_fingerprint": "<system_fingerprint>",
                   "tokenUsage": {
-                    "completionTokens": 4,
-                    "promptTokens": 15,
-                    "totalTokens": 19
-                  },
-                  "usage": {
-                    "completion_tokens": 4,
-                    "completion_tokens_details": {
-                      "accepted_prediction_tokens": 0,
-                      "audio_tokens": 0,
-                      "reasoning_tokens": 0,
-                      "rejected_prediction_tokens": 0
-                    },
-                    "prompt_tokens": 15,
-                    "prompt_tokens_details": {
-                      "audio_tokens": 0,
-                      "cached_tokens": 0
-                    },
-                    "total_tokens": 19
+                    "completionTokens": 205,
+                    "promptTokens": 14,
+                    "totalTokens": 219
                   }
                 },
                 "tool_calls": [],
@@ -328,7 +308,7 @@
                   "input_tokens": "<number>",
                   "output_token_details": {
                     "audio": 0,
-                    "reasoning": 0
+                    "reasoning": 192
                   },
                   "output_tokens": "<number>",
                   "total_tokens": "<number>"
@@ -343,9 +323,9 @@
       ],
       "llmOutput": {
         "tokenUsage": {
-          "completionTokens": 4,
-          "promptTokens": 15,
-          "totalTokens": 19
+          "completionTokens": 205,
+          "promptTokens": 14,
+          "totalTokens": 219
         }
       }
     },
@@ -373,11 +353,10 @@
     ],
     "log_id": "g",
     "metadata": {
-      "max_tokens": 24,
-      "model": "gpt-4o-mini-2024-07-18",
+      "max_completion_tokens": 4000,
+      "model": "gpt-5-nano",
       "provider": "openai",
-      "stream": false,
-      "temperature": 0
+      "stream": false
     },
     "metrics": {
       "completion_accepted_prediction_tokens": "<number>",
@@ -397,7 +376,6 @@
       {
         "finish_reason": "stop",
         "index": 0,
-        "logprobs": null,
         "message": {
           "annotations": [],
           "content": "hello from langgraph",

--- a/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1-latest.span-tree.json
+++ b/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1-latest.span-tree.json
@@ -54,28 +54,12 @@
                               "invalid_tool_calls": [],
                               "response_metadata": {
                                 "finish_reason": "stop",
-                                "model_name": "gpt-4o-mini-2024-07-18",
+                                "model_name": "gpt-5-nano-2025-08-07",
                                 "model_provider": "openai",
-                                "system_fingerprint": "<system_fingerprint>",
                                 "tokenUsage": {
-                                  "completionTokens": 4,
-                                  "promptTokens": 15,
-                                  "totalTokens": 19
-                                },
-                                "usage": {
-                                  "completion_tokens": 4,
-                                  "completion_tokens_details": {
-                                    "accepted_prediction_tokens": 0,
-                                    "audio_tokens": 0,
-                                    "reasoning_tokens": 0,
-                                    "rejected_prediction_tokens": 0
-                                  },
-                                  "prompt_tokens": 15,
-                                  "prompt_tokens_details": {
-                                    "audio_tokens": 0,
-                                    "cached_tokens": 0
-                                  },
-                                  "total_tokens": 19
+                                  "completionTokens": 205,
+                                  "promptTokens": 14,
+                                  "totalTokens": 219
                                 }
                               },
                               "tool_calls": [],
@@ -85,13 +69,13 @@
                                   "audio": 0,
                                   "cache_read": 0
                                 },
-                                "input_tokens": 15,
+                                "input_tokens": 14,
                                 "output_token_details": {
                                   "audio": 0,
-                                  "reasoning": 0
+                                  "reasoning": 192
                                 },
-                                "output_tokens": 4,
-                                "total_tokens": 19
+                                "output_tokens": 205,
+                                "total_tokens": 219
                               }
                             },
                             "lc": 1,
@@ -103,22 +87,22 @@
                     ],
                     "llmOutput": {
                       "tokenUsage": {
-                        "completionTokens": 4,
-                        "promptTokens": 15,
-                        "totalTokens": 19
+                        "completionTokens": 205,
+                        "promptTokens": 14,
+                        "totalTokens": 219
                       }
                     }
                   },
                   "metadata": {
-                    "model": "gpt-4o-mini-2024-07-18"
+                    "model": "gpt-5-nano-2025-08-07"
                   },
-                  "metric_keys": [
-                    "completion_reasoning_tokens",
-                    "completion_tokens",
-                    "prompt_cached_tokens",
-                    "prompt_tokens",
-                    "tokens"
-                  ]
+                  "metrics": {
+                    "completion_reasoning_tokens": 192,
+                    "completion_tokens": 205,
+                    "prompt_cached_tokens": 0,
+                    "prompt_tokens": 14,
+                    "tokens": 219
+                  }
                 }
               ],
               "input": {

--- a/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1-latest.span-tree.json
+++ b/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1-latest.span-tree.json
@@ -113,6 +113,7 @@
                     "model": "gpt-4o-mini-2024-07-18"
                   },
                   "metric_keys": [
+                    "completion_reasoning_tokens",
                     "completion_tokens",
                     "prompt_cached_tokens",
                     "prompt_tokens",

--- a/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1-latest.span-tree.txt
+++ b/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1-latest.span-tree.txt
@@ -54,28 +54,12 @@ span_tree:
         │                   "invalid_tool_calls": [],
         │                   "response_metadata": {
         │                     "finish_reason": "stop",
-        │                     "model_name": "gpt-4o-mini-2024-07-18",
+        │                     "model_name": "gpt-5-nano-2025-08-07",
         │                     "model_provider": "openai",
-        │                     "system_fingerprint": "<system_fingerprint>",
         │                     "tokenUsage": {
-        │                       "completionTokens": 4,
-        │                       "promptTokens": 15,
-        │                       "totalTokens": 19
-        │                     },
-        │                     "usage": {
-        │                       "completion_tokens": 4,
-        │                       "completion_tokens_details": {
-        │                         "accepted_prediction_tokens": 0,
-        │                         "audio_tokens": 0,
-        │                         "reasoning_tokens": 0,
-        │                         "rejected_prediction_tokens": 0
-        │                       },
-        │                       "prompt_tokens": 15,
-        │                       "prompt_tokens_details": {
-        │                         "audio_tokens": 0,
-        │                         "cached_tokens": 0
-        │                       },
-        │                       "total_tokens": 19
+        │                       "completionTokens": 205,
+        │                       "promptTokens": 14,
+        │                       "totalTokens": 219
         │                     }
         │                   },
         │                   "tool_calls": [],
@@ -85,13 +69,13 @@ span_tree:
         │                       "audio": 0,
         │                       "cache_read": 0
         │                     },
-        │                     "input_tokens": 15,
+        │                     "input_tokens": 14,
         │                     "output_token_details": {
         │                       "audio": 0,
-        │                       "reasoning": 0
+        │                       "reasoning": 192
         │                     },
-        │                     "output_tokens": 4,
-        │                     "total_tokens": 19
+        │                     "output_tokens": 205,
+        │                     "total_tokens": 219
         │                   }
         │                 },
         │                 "lc": 1,
@@ -103,22 +87,22 @@ span_tree:
         │         ],
         │         "llmOutput": {
         │           "tokenUsage": {
-        │             "completionTokens": 4,
-        │             "promptTokens": 15,
-        │             "totalTokens": 19
+        │             "completionTokens": 205,
+        │             "promptTokens": 14,
+        │             "totalTokens": 219
         │           }
         │         }
         │       }
         │       metadata: {
-        │         "model": "gpt-4o-mini-2024-07-18"
+        │         "model": "gpt-5-nano-2025-08-07"
         │       }
-        │       metric_keys: [
-        │         "completion_reasoning_tokens",
-        │         "completion_tokens",
-        │         "prompt_cached_tokens",
-        │         "prompt_tokens",
-        │         "tokens"
-        │       ]
+        │       metrics: {
+        │         "completion_reasoning_tokens": 192,
+        │         "completion_tokens": 205,
+        │         "prompt_cached_tokens": 0,
+        │         "prompt_tokens": 14,
+        │         "tokens": 219
+        │       }
         └── sayBye [task]
             input: {
               "message": "hello from langgraph"

--- a/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1-latest.span-tree.txt
+++ b/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1-latest.span-tree.txt
@@ -113,6 +113,7 @@ span_tree:
         │         "model": "gpt-4o-mini-2024-07-18"
         │       }
         │       metric_keys: [
+        │         "completion_reasoning_tokens",
         │         "completion_tokens",
         │         "prompt_cached_tokens",
         │         "prompt_tokens",

--- a/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1.log-payloads.json
+++ b/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1.log-payloads.json
@@ -265,6 +265,7 @@
       "tags": []
     },
     "metrics": {
+      "completion_reasoning_tokens": "<number>",
       "completion_tokens": "<number>",
       "end": 0,
       "prompt_cached_tokens": "<number>",

--- a/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1.log-payloads.json
+++ b/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1.log-payloads.json
@@ -207,10 +207,9 @@
         "sdk_language": "javascript"
       },
       "invocation_params": {
-        "max_tokens": 24,
-        "model": "gpt-4o-mini-2024-07-18",
-        "stream": false,
-        "temperature": 0
+        "max_completion_tokens": 4000,
+        "model": "gpt-5-nano",
+        "stream": false
       },
       "metadata": {
         "checkpoint_ns": "sayHello:<uuid:9>",
@@ -224,17 +223,15 @@
         "langgraph_triggers": [
           "branch:to:sayHello"
         ],
-        "ls_max_tokens": 24,
-        "ls_model_name": "gpt-4o-mini-2024-07-18",
+        "ls_model_name": "gpt-5-nano",
         "ls_model_type": "chat",
         "ls_provider": "openai",
-        "ls_temperature": 0,
         "versions": {
           "@langchain/core": "<langchain-version>",
           "@langchain/openai": "<langchain-version>"
         }
       },
-      "model": "gpt-4o-mini-2024-07-18",
+      "model": "gpt-5-nano-2025-08-07",
       "options": {
         "signal": {}
       },
@@ -248,16 +245,15 @@
           "ChatOpenAI"
         ],
         "kwargs": {
-          "max_tokens": 24,
-          "model": "gpt-4o-mini-2024-07-18",
+          "max_tokens": 4000,
+          "model": "gpt-5-nano",
           "openai_api_key": {
             "id": [
               "OPENAI_API_KEY"
             ],
             "lc": 1,
             "type": "secret"
-          },
-          "temperature": 0
+          }
         },
         "lc": 1,
         "type": "constructor"
@@ -293,28 +289,12 @@
                 "invalid_tool_calls": [],
                 "response_metadata": {
                   "finish_reason": "stop",
-                  "model_name": "gpt-4o-mini-2024-07-18",
+                  "model_name": "gpt-5-nano-2025-08-07",
                   "model_provider": "openai",
-                  "system_fingerprint": "<system_fingerprint>",
                   "tokenUsage": {
-                    "completionTokens": 4,
-                    "promptTokens": 15,
-                    "totalTokens": 19
-                  },
-                  "usage": {
-                    "completion_tokens": 4,
-                    "completion_tokens_details": {
-                      "accepted_prediction_tokens": 0,
-                      "audio_tokens": 0,
-                      "reasoning_tokens": 0,
-                      "rejected_prediction_tokens": 0
-                    },
-                    "prompt_tokens": 15,
-                    "prompt_tokens_details": {
-                      "audio_tokens": 0,
-                      "cached_tokens": 0
-                    },
-                    "total_tokens": 19
+                    "completionTokens": 141,
+                    "promptTokens": 14,
+                    "totalTokens": 155
                   }
                 },
                 "tool_calls": [],
@@ -327,7 +307,7 @@
                   "input_tokens": "<number>",
                   "output_token_details": {
                     "audio": 0,
-                    "reasoning": 0
+                    "reasoning": 128
                   },
                   "output_tokens": "<number>",
                   "total_tokens": "<number>"
@@ -342,9 +322,9 @@
       ],
       "llmOutput": {
         "tokenUsage": {
-          "completionTokens": 4,
-          "promptTokens": 15,
-          "totalTokens": 19
+          "completionTokens": 141,
+          "promptTokens": 14,
+          "totalTokens": 155
         }
       }
     },
@@ -372,11 +352,10 @@
     ],
     "log_id": "g",
     "metadata": {
-      "max_tokens": 24,
-      "model": "gpt-4o-mini-2024-07-18",
+      "max_completion_tokens": 4000,
+      "model": "gpt-5-nano",
       "provider": "openai",
-      "stream": false,
-      "temperature": 0
+      "stream": false
     },
     "metrics": {
       "completion_accepted_prediction_tokens": "<number>",
@@ -396,7 +375,6 @@
       {
         "finish_reason": "stop",
         "index": 0,
-        "logprobs": null,
         "message": {
           "annotations": [],
           "content": "hello from langgraph",

--- a/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1.span-tree.json
+++ b/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1.span-tree.json
@@ -113,6 +113,7 @@
                     "model": "gpt-4o-mini-2024-07-18"
                   },
                   "metric_keys": [
+                    "completion_reasoning_tokens",
                     "completion_tokens",
                     "prompt_cached_tokens",
                     "prompt_tokens",

--- a/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1.span-tree.json
+++ b/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1.span-tree.json
@@ -54,28 +54,12 @@
                               "invalid_tool_calls": [],
                               "response_metadata": {
                                 "finish_reason": "stop",
-                                "model_name": "gpt-4o-mini-2024-07-18",
+                                "model_name": "gpt-5-nano-2025-08-07",
                                 "model_provider": "openai",
-                                "system_fingerprint": "<system_fingerprint>",
                                 "tokenUsage": {
-                                  "completionTokens": 4,
-                                  "promptTokens": 15,
-                                  "totalTokens": 19
-                                },
-                                "usage": {
-                                  "completion_tokens": 4,
-                                  "completion_tokens_details": {
-                                    "accepted_prediction_tokens": 0,
-                                    "audio_tokens": 0,
-                                    "reasoning_tokens": 0,
-                                    "rejected_prediction_tokens": 0
-                                  },
-                                  "prompt_tokens": 15,
-                                  "prompt_tokens_details": {
-                                    "audio_tokens": 0,
-                                    "cached_tokens": 0
-                                  },
-                                  "total_tokens": 19
+                                  "completionTokens": 141,
+                                  "promptTokens": 14,
+                                  "totalTokens": 155
                                 }
                               },
                               "tool_calls": [],
@@ -85,13 +69,13 @@
                                   "audio": 0,
                                   "cache_read": 0
                                 },
-                                "input_tokens": 15,
+                                "input_tokens": 14,
                                 "output_token_details": {
                                   "audio": 0,
-                                  "reasoning": 0
+                                  "reasoning": 128
                                 },
-                                "output_tokens": 4,
-                                "total_tokens": 19
+                                "output_tokens": 141,
+                                "total_tokens": 155
                               }
                             },
                             "lc": 1,
@@ -103,22 +87,22 @@
                     ],
                     "llmOutput": {
                       "tokenUsage": {
-                        "completionTokens": 4,
-                        "promptTokens": 15,
-                        "totalTokens": 19
+                        "completionTokens": 141,
+                        "promptTokens": 14,
+                        "totalTokens": 155
                       }
                     }
                   },
                   "metadata": {
-                    "model": "gpt-4o-mini-2024-07-18"
+                    "model": "gpt-5-nano-2025-08-07"
                   },
-                  "metric_keys": [
-                    "completion_reasoning_tokens",
-                    "completion_tokens",
-                    "prompt_cached_tokens",
-                    "prompt_tokens",
-                    "tokens"
-                  ]
+                  "metrics": {
+                    "completion_reasoning_tokens": 128,
+                    "completion_tokens": 141,
+                    "prompt_cached_tokens": 0,
+                    "prompt_tokens": 14,
+                    "tokens": 155
+                  }
                 }
               ],
               "input": {

--- a/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1.span-tree.txt
+++ b/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1.span-tree.txt
@@ -54,28 +54,12 @@ span_tree:
         │                   "invalid_tool_calls": [],
         │                   "response_metadata": {
         │                     "finish_reason": "stop",
-        │                     "model_name": "gpt-4o-mini-2024-07-18",
+        │                     "model_name": "gpt-5-nano-2025-08-07",
         │                     "model_provider": "openai",
-        │                     "system_fingerprint": "<system_fingerprint>",
         │                     "tokenUsage": {
-        │                       "completionTokens": 4,
-        │                       "promptTokens": 15,
-        │                       "totalTokens": 19
-        │                     },
-        │                     "usage": {
-        │                       "completion_tokens": 4,
-        │                       "completion_tokens_details": {
-        │                         "accepted_prediction_tokens": 0,
-        │                         "audio_tokens": 0,
-        │                         "reasoning_tokens": 0,
-        │                         "rejected_prediction_tokens": 0
-        │                       },
-        │                       "prompt_tokens": 15,
-        │                       "prompt_tokens_details": {
-        │                         "audio_tokens": 0,
-        │                         "cached_tokens": 0
-        │                       },
-        │                       "total_tokens": 19
+        │                       "completionTokens": 141,
+        │                       "promptTokens": 14,
+        │                       "totalTokens": 155
         │                     }
         │                   },
         │                   "tool_calls": [],
@@ -85,13 +69,13 @@ span_tree:
         │                       "audio": 0,
         │                       "cache_read": 0
         │                     },
-        │                     "input_tokens": 15,
+        │                     "input_tokens": 14,
         │                     "output_token_details": {
         │                       "audio": 0,
-        │                       "reasoning": 0
+        │                       "reasoning": 128
         │                     },
-        │                     "output_tokens": 4,
-        │                     "total_tokens": 19
+        │                     "output_tokens": 141,
+        │                     "total_tokens": 155
         │                   }
         │                 },
         │                 "lc": 1,
@@ -103,22 +87,22 @@ span_tree:
         │         ],
         │         "llmOutput": {
         │           "tokenUsage": {
-        │             "completionTokens": 4,
-        │             "promptTokens": 15,
-        │             "totalTokens": 19
+        │             "completionTokens": 141,
+        │             "promptTokens": 14,
+        │             "totalTokens": 155
         │           }
         │         }
         │       }
         │       metadata: {
-        │         "model": "gpt-4o-mini-2024-07-18"
+        │         "model": "gpt-5-nano-2025-08-07"
         │       }
-        │       metric_keys: [
-        │         "completion_reasoning_tokens",
-        │         "completion_tokens",
-        │         "prompt_cached_tokens",
-        │         "prompt_tokens",
-        │         "tokens"
-        │       ]
+        │       metrics: {
+        │         "completion_reasoning_tokens": 128,
+        │         "completion_tokens": 141,
+        │         "prompt_cached_tokens": 0,
+        │         "prompt_tokens": 14,
+        │         "tokens": 155
+        │       }
         └── sayBye [task]
             input: {
               "message": "hello from langgraph"

--- a/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1.span-tree.txt
+++ b/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/langgraph-v1.span-tree.txt
@@ -113,6 +113,7 @@ span_tree:
         │         "model": "gpt-4o-mini-2024-07-18"
         │       }
         │       metric_keys: [
+        │         "completion_reasoning_tokens",
         │         "completion_tokens",
         │         "prompt_cached_tokens",
         │         "prompt_tokens",

--- a/e2e/scenarios/langgraph-auto-instrumentation/assertions.ts
+++ b/e2e/scenarios/langgraph-auto-instrumentation/assertions.ts
@@ -29,12 +29,14 @@ function findDescendantSpan(
     }
     visited.add(current);
 
+    const matchingSpan = findChildSpans(events, name, current).find(predicate);
+    if (matchingSpan) {
+      return matchingSpan;
+    }
+
     for (const event of events) {
       if (!event.span.parentIds.includes(current)) {
         continue;
-      }
-      if (event.span.name === name && predicate(event)) {
-        return event;
       }
       if (event.span.id) {
         queue.push(event.span.id);
@@ -231,10 +233,12 @@ export function assertLangGraphAutoInstrumentation(options: {
   expect(llmSpan).toBeDefined();
   expect(llmSpan?.span.type).toBe("llm");
   expect(llmSpan?.metrics).toMatchObject({
+    completion_reasoning_tokens: expect.any(Number),
     completion_tokens: expect.any(Number),
     prompt_tokens: expect.any(Number),
     tokens: expect.any(Number),
   });
+  expect(llmSpan?.metrics?.completion_reasoning_tokens).toBeGreaterThan(0);
 
   const spanTree = [root, graphSpan, sayHelloSpan, llmSpan, sayByeSpan].map(
     (event) => {
@@ -249,13 +253,6 @@ export function assertLangGraphAutoInstrumentation(options: {
               ),
             )
           : undefined;
-      const metricKeys =
-        fields.metrics &&
-        typeof fields.metrics === "object" &&
-        !Array.isArray(fields.metrics)
-          ? Object.keys(fields.metrics).sort()
-          : undefined;
-
       return {
         event: event!,
         fields: {
@@ -263,8 +260,7 @@ export function assertLangGraphAutoInstrumentation(options: {
           input: snapshotIOValue(fields.input),
           output: snapshotIOValue(fields.output),
           metadata,
-          metric_keys:
-            metricKeys && metricKeys.length > 0 ? metricKeys : undefined,
+          metrics: fields.metrics,
         },
       };
     },

--- a/e2e/scenarios/langgraph-auto-instrumentation/scenario.mjs
+++ b/e2e/scenarios/langgraph-auto-instrumentation/scenario.mjs
@@ -12,7 +12,7 @@ const { ChatOpenAI } = await import(langchainOpenAIPackageName);
 import { runMain, runTracedScenario } from "../../helpers/provider-runtime.mjs";
 import { ROOT_NAME, SCENARIO_NAME } from "./constants.mjs";
 
-const OPENAI_MODEL = "gpt-4o-mini-2024-07-18";
+const OPENAI_MODEL = "gpt-5-nano";
 
 runMain(async () => {
   await runTracedScenario({
@@ -26,8 +26,7 @@ runMain(async () => {
 
       const model = new ChatOpenAI({
         model: OPENAI_MODEL,
-        maxTokens: 24,
-        temperature: 0,
+        maxTokens: 4_000,
       });
 
       async function sayHello() {

--- a/e2e/scenarios/wrap-langchain-js-traces/__cassettes__/wrap-langchain-js-traces-v1-latest.cassette.json
+++ b/e2e/scenarios/wrap-langchain-js-traces/__cassettes__/wrap-langchain-js-traces-v1-latest.cassette.json
@@ -2,23 +2,22 @@
   "entries": [
     {
       "callIndex": 0,
-      "id": "fe18d9d8136a510f",
+      "id": "86e93f0671afd2fb",
       "matchKey": "POST api.openai.com/v1/chat/completions",
-      "recordedAt": "2026-07-07T13:51:49.845Z",
+      "recordedAt": "2026-08-24T12:20:32.278Z",
       "request": {
         "body": {
           "kind": "json",
           "value": {
-            "max_tokens": 24,
+            "max_completion_tokens": 512,
             "messages": [
               {
                 "content": "Reply with exactly OK.",
                 "role": "user"
               }
             ],
-            "model": "gpt-4o-mini-2024-07-18",
-            "stream": false,
-            "temperature": 0
+            "model": "gpt-5-nano",
+            "stream": false
           }
         },
         "headers": {},
@@ -33,35 +32,34 @@
               {
                 "finish_reason": "stop",
                 "index": 0,
-                "logprobs": null,
                 "message": {
                   "annotations": [],
-                  "content": "OK.",
+                  "content": "OK",
                   "refusal": null,
                   "role": "assistant"
                 }
               }
             ],
-            "created": 1783432309,
-            "id": "chatcmpl-Dz0VBXwRjpKfNHwYYi7bY3Lzo3aFg",
-            "model": "gpt-4o-mini-2024-07-18",
+            "created": 1787574030,
+            "id": "chatcmpl-EGNx8tOIBqW4PL9inY296btKeUCr1",
+            "model": "gpt-5-nano-2025-08-07",
             "object": "chat.completion",
             "service_tier": "default",
-            "system_fingerprint": "fp_f8eef96d28",
+            "system_fingerprint": null,
             "usage": {
-              "completion_tokens": 2,
+              "completion_tokens": 266,
               "completion_tokens_details": {
                 "accepted_prediction_tokens": 0,
                 "audio_tokens": 0,
-                "reasoning_tokens": 0,
+                "reasoning_tokens": 256,
                 "rejected_prediction_tokens": 0
               },
-              "prompt_tokens": 12,
+              "prompt_tokens": 11,
               "prompt_tokens_details": {
                 "audio_tokens": 0,
                 "cached_tokens": 0
               },
-              "total_tokens": 14
+              "total_tokens": 277
             }
           }
         },
@@ -69,13 +67,13 @@
           "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
           "alt-svc": "h3=\":443\"; ma=86400",
           "cf-cache-status": "DYNAMIC",
-          "cf-ray": "a177537ccf575b7f-VIE",
+          "cf-ray": "a3024fb8088a2fd0-IAD",
           "connection": "keep-alive",
           "content-encoding": "gzip",
           "content-type": "application/json",
-          "date": "Tue, 07 Jul 2026 13:51:49 GMT",
+          "date": "Mon, 24 Aug 2026 12:20:32 GMT",
           "openai-organization": "braintrust-data",
-          "openai-processing-ms": "484",
+          "openai-processing-ms": "2073",
           "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
           "openai-version": "2020-10-01",
           "server": "cloudflare",
@@ -85,12 +83,12 @@
           "x-content-type-options": "nosniff",
           "x-openai-proxy-wasm": "v0.1",
           "x-ratelimit-limit-requests": "30000",
-          "x-ratelimit-limit-tokens": "150000000",
+          "x-ratelimit-limit-tokens": "180000000",
           "x-ratelimit-remaining-requests": "29999",
-          "x-ratelimit-remaining-tokens": "149999992",
+          "x-ratelimit-remaining-tokens": "179999994",
           "x-ratelimit-reset-requests": "2ms",
           "x-ratelimit-reset-tokens": "0s",
-          "x-request-id": "req_bef6f2b5330040209bba405d9fd9e0f2"
+          "x-request-id": "req_4371b279cf104e0697b031338add78f2"
         },
         "status": 200,
         "statusText": "OK"
@@ -100,7 +98,7 @@
       "callIndex": 1,
       "id": "a613a13df4910706",
       "matchKey": "POST api.openai.com/v1/chat/completions",
-      "recordedAt": "2026-07-07T13:51:50.319Z",
+      "recordedAt": "2026-08-24T12:20:32.699Z",
       "request": {
         "body": {
           "kind": "json",
@@ -138,12 +136,12 @@
                 }
               }
             ],
-            "created": 1783432310,
-            "id": "chatcmpl-Dz0VC23tRmo6wpixfxAhINoaovAHK",
+            "created": 1787574032,
+            "id": "chatcmpl-EGNxAPgSJsXEVlK5YEAjNpYLSUFML",
             "model": "gpt-4o-mini-2024-07-18",
             "object": "chat.completion",
             "service_tier": "default",
-            "system_fingerprint": "fp_d0469e1700",
+            "system_fingerprint": "fp_fabbcdf5d9",
             "usage": {
               "completion_tokens": 2,
               "completion_tokens_details": {
@@ -165,13 +163,13 @@
           "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
           "alt-svc": "h3=\":443\"; ma=86400",
           "cf-cache-status": "DYNAMIC",
-          "cf-ray": "a177538109a25b7f-VIE",
+          "cf-ray": "a3024fc59a5b2fd0-IAD",
           "connection": "keep-alive",
           "content-encoding": "gzip",
           "content-type": "application/json",
-          "date": "Tue, 07 Jul 2026 13:51:50 GMT",
+          "date": "Mon, 24 Aug 2026 12:20:32 GMT",
           "openai-organization": "braintrust-data",
-          "openai-processing-ms": "264",
+          "openai-processing-ms": "338",
           "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
           "openai-version": "2020-10-01",
           "server": "cloudflare",
@@ -186,7 +184,7 @@
           "x-ratelimit-remaining-tokens": "149999985",
           "x-ratelimit-reset-requests": "2ms",
           "x-ratelimit-reset-tokens": "0s",
-          "x-request-id": "req_dd2d48423d0449299c3ffed5541e04fe"
+          "x-request-id": "req_6de919b320864952a77010c3682478ac"
         },
         "status": 200,
         "statusText": "OK"
@@ -196,7 +194,7 @@
       "callIndex": 2,
       "id": "394c0994869e6e1f",
       "matchKey": "POST api.openai.com/v1/chat/completions",
-      "recordedAt": "2026-07-07T13:51:50.923Z",
+      "recordedAt": "2026-08-24T12:20:33.104Z",
       "request": {
         "body": {
           "kind": "json",
@@ -223,15 +221,15 @@
       "response": {
         "body": {
           "chunks": [
-            "data: {\"id\":\"chatcmpl-Dz0VCaQi4fWxu1E2UuPfWMCKXvRsu\",\"object\":\"chat.completion.chunk\",\"created\":1783432310,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"pj7EO8oPX\"}",
-            "data: {\"id\":\"chatcmpl-Dz0VCaQi4fWxu1E2UuPfWMCKXvRsu\",\"object\":\"chat.completion.chunk\",\"created\":1783432310,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"One\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"QWD03vxE\"}",
-            "data: {\"id\":\"chatcmpl-Dz0VCaQi4fWxu1E2UuPfWMCKXvRsu\",\"object\":\"chat.completion.chunk\",\"created\":1783432310,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\",\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"MtH6Y3pWDl\"}",
-            "data: {\"id\":\"chatcmpl-Dz0VCaQi4fWxu1E2UuPfWMCKXvRsu\",\"object\":\"chat.completion.chunk\",\"created\":1783432310,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" two\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"jhdDahL\"}",
-            "data: {\"id\":\"chatcmpl-Dz0VCaQi4fWxu1E2UuPfWMCKXvRsu\",\"object\":\"chat.completion.chunk\",\"created\":1783432310,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\",\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"3TddNPlu86\"}",
-            "data: {\"id\":\"chatcmpl-Dz0VCaQi4fWxu1E2UuPfWMCKXvRsu\",\"object\":\"chat.completion.chunk\",\"created\":1783432310,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" three\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"L1esn\"}",
-            "data: {\"id\":\"chatcmpl-Dz0VCaQi4fWxu1E2UuPfWMCKXvRsu\",\"object\":\"chat.completion.chunk\",\"created\":1783432310,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\".\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"Ip6ebxprSe\"}",
-            "data: {\"id\":\"chatcmpl-Dz0VCaQi4fWxu1E2UuPfWMCKXvRsu\",\"object\":\"chat.completion.chunk\",\"created\":1783432310,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"usage\":null,\"obfuscation\":\"ebbC5\"}",
-            "data: {\"id\":\"chatcmpl-Dz0VCaQi4fWxu1E2UuPfWMCKXvRsu\",\"object\":\"chat.completion.chunk\",\"created\":1783432310,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[],\"usage\":{\"prompt_tokens\":22,\"completion_tokens\":6,\"total_tokens\":28,\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}},\"obfuscation\":\"LigTuXTOD93\"}",
+            "data: {\"id\":\"chatcmpl-EGNxAtVgtjTY51DEVaYfresrdBMst\",\"object\":\"chat.completion.chunk\",\"created\":1787574032,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"wxWQ0eCDL\"}",
+            "data: {\"id\":\"chatcmpl-EGNxAtVgtjTY51DEVaYfresrdBMst\",\"object\":\"chat.completion.chunk\",\"created\":1787574032,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"One\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"uje9Teyd\"}",
+            "data: {\"id\":\"chatcmpl-EGNxAtVgtjTY51DEVaYfresrdBMst\",\"object\":\"chat.completion.chunk\",\"created\":1787574032,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\",\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"B0K64QetnP\"}",
+            "data: {\"id\":\"chatcmpl-EGNxAtVgtjTY51DEVaYfresrdBMst\",\"object\":\"chat.completion.chunk\",\"created\":1787574032,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" two\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"S4dypzF\"}",
+            "data: {\"id\":\"chatcmpl-EGNxAtVgtjTY51DEVaYfresrdBMst\",\"object\":\"chat.completion.chunk\",\"created\":1787574032,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\",\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"XdqizbjE0P\"}",
+            "data: {\"id\":\"chatcmpl-EGNxAtVgtjTY51DEVaYfresrdBMst\",\"object\":\"chat.completion.chunk\",\"created\":1787574032,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" three\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"Bq0Q1\"}",
+            "data: {\"id\":\"chatcmpl-EGNxAtVgtjTY51DEVaYfresrdBMst\",\"object\":\"chat.completion.chunk\",\"created\":1787574032,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\".\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"BoOsWxwVOZ\"}",
+            "data: {\"id\":\"chatcmpl-EGNxAtVgtjTY51DEVaYfresrdBMst\",\"object\":\"chat.completion.chunk\",\"created\":1787574032,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"usage\":null,\"obfuscation\":\"OgqTv\"}",
+            "data: {\"id\":\"chatcmpl-EGNxAtVgtjTY51DEVaYfresrdBMst\",\"object\":\"chat.completion.chunk\",\"created\":1787574032,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[],\"usage\":{\"prompt_tokens\":22,\"completion_tokens\":6,\"total_tokens\":28,\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}},\"obfuscation\":\"3mFwIC92nf0\"}",
             "data: [DONE]"
           ],
           "kind": "sse"
@@ -240,12 +238,12 @@
           "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
           "alt-svc": "h3=\":443\"; ma=86400",
           "cf-cache-status": "DYNAMIC",
-          "cf-ray": "a1775383fb9f5b7f-VIE",
+          "cf-ray": "a3024fc82b622fd0-IAD",
           "connection": "keep-alive",
           "content-type": "text/event-stream; charset=utf-8",
-          "date": "Tue, 07 Jul 2026 13:51:50 GMT",
+          "date": "Mon, 24 Aug 2026 12:20:32 GMT",
           "openai-organization": "braintrust-data",
-          "openai-processing-ms": "310",
+          "openai-processing-ms": "244",
           "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
           "openai-version": "2020-10-01",
           "server": "cloudflare",
@@ -257,10 +255,10 @@
           "x-ratelimit-limit-requests": "30000",
           "x-ratelimit-limit-tokens": "150000000",
           "x-ratelimit-remaining-requests": "29999",
-          "x-ratelimit-remaining-tokens": "149999985",
+          "x-ratelimit-remaining-tokens": "149999982",
           "x-ratelimit-reset-requests": "2ms",
           "x-ratelimit-reset-tokens": "0s",
-          "x-request-id": "req_150609b8a3594d6599f9730d9cee6e63"
+          "x-request-id": "req_0be6fc8fedbe4d70805e3b1ab80f25cf"
         },
         "status": 200,
         "statusText": "OK"
@@ -270,7 +268,7 @@
       "callIndex": 3,
       "id": "7f1e5cd685579c33",
       "matchKey": "POST api.openai.com/v1/chat/completions",
-      "recordedAt": "2026-07-07T13:51:51.567Z",
+      "recordedAt": "2026-08-24T12:20:33.721Z",
       "request": {
         "body": {
           "kind": "json",
@@ -332,19 +330,19 @@
                         "arguments": "{\"location\":\"Paris, France\"}",
                         "name": "get_weather"
                       },
-                      "id": "call_o9ucelGtKtGBOvsXYIQaVr99",
+                      "id": "call_qjYJazVqODvAan4YaPgZZ8ra",
                       "type": "function"
                     }
                   ]
                 }
               }
             ],
-            "created": 1783432311,
-            "id": "chatcmpl-Dz0VDjeAaXBTbi5Kh60GcLntJTGut",
+            "created": 1787574033,
+            "id": "chatcmpl-EGNxB4gTTflGWk1BHpKwKrYsdlH75",
             "model": "gpt-4o-mini-2024-07-18",
             "object": "chat.completion",
             "service_tier": "default",
-            "system_fingerprint": "fp_3516695052",
+            "system_fingerprint": "fp_02ae59e84c",
             "usage": {
               "completion_tokens": 16,
               "completion_tokens_details": {
@@ -366,13 +364,13 @@
           "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
           "alt-svc": "h3=\":443\"; ma=86400",
           "cf-cache-status": "DYNAMIC",
-          "cf-ray": "a1775387cdf35b7f-VIE",
+          "cf-ray": "a3024fcabbd32fd0-IAD",
           "connection": "keep-alive",
           "content-encoding": "gzip",
           "content-type": "application/json",
-          "date": "Tue, 07 Jul 2026 13:51:51 GMT",
+          "date": "Mon, 24 Aug 2026 12:20:33 GMT",
           "openai-organization": "braintrust-data",
-          "openai-processing-ms": "434",
+          "openai-processing-ms": "546",
           "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
           "openai-version": "2020-10-01",
           "server": "cloudflare",
@@ -387,7 +385,7 @@
           "x-ratelimit-remaining-tokens": "149999980",
           "x-ratelimit-reset-requests": "2ms",
           "x-ratelimit-reset-tokens": "0s",
-          "x-request-id": "req_1d8a8dae9e52473493cc658d7208705f"
+          "x-request-id": "req_ded6c40040e749c49af0e74794677f16"
         },
         "status": 200,
         "statusText": "OK"
@@ -397,7 +395,7 @@
       "callIndex": 4,
       "id": "92b304bbb4ce5170",
       "matchKey": "POST api.openai.com/v1/chat/completions",
-      "recordedAt": "2026-07-07T13:51:52.773Z",
+      "recordedAt": "2026-08-24T12:20:34.417Z",
       "request": {
         "body": {
           "kind": "json",
@@ -465,19 +463,19 @@
                         "arguments": "{\"operation\":\"multiply\",\"a\":127,\"b\":49}",
                         "name": "calculate"
                       },
-                      "id": "call_lcOSg1ZwQk3T0mSSMO95zd95",
+                      "id": "call_BMkQ0blzGQeVPEC7pIElPdRs",
                       "type": "function"
                     }
                   ]
                 }
               }
             ],
-            "created": 1783432311,
-            "id": "chatcmpl-Dz0VD9I8hoVTLDwGRsyOpBYEcKDtc",
+            "created": 1787574033,
+            "id": "chatcmpl-EGNxBqL6zQDAnMT6RdDBaUwkEjbWf",
             "model": "gpt-4o-mini-2024-07-18",
             "object": "chat.completion",
             "service_tier": "default",
-            "system_fingerprint": "fp_39589d11a4",
+            "system_fingerprint": "fp_0950b7f384",
             "usage": {
               "completion_tokens": 21,
               "completion_tokens_details": {
@@ -499,13 +497,13 @@
           "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
           "alt-svc": "h3=\":443\"; ma=86400",
           "cf-cache-status": "DYNAMIC",
-          "cf-ray": "a177538bb86e5b7f-VIE",
+          "cf-ray": "a3024fce88f42fd0-IAD",
           "connection": "keep-alive",
           "content-encoding": "gzip",
           "content-type": "application/json",
-          "date": "Tue, 07 Jul 2026 13:51:52 GMT",
+          "date": "Mon, 24 Aug 2026 12:20:34 GMT",
           "openai-organization": "braintrust-data",
-          "openai-processing-ms": "1009",
+          "openai-processing-ms": "617",
           "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
           "openai-version": "2020-10-01",
           "server": "cloudflare",
@@ -520,7 +518,7 @@
           "x-ratelimit-remaining-tokens": "149999985",
           "x-ratelimit-reset-requests": "2ms",
           "x-ratelimit-reset-tokens": "0s",
-          "x-request-id": "req_f1b5aea1f1304c059653840d76724596"
+          "x-request-id": "req_d320b09ebbc6405cab6edb5dc6a5e0c1"
         },
         "status": 200,
         "statusText": "OK"
@@ -528,9 +526,9 @@
     },
     {
       "callIndex": 5,
-      "id": "888892d503249523",
+      "id": "6fa54a31e7345249",
       "matchKey": "POST api.openai.com/v1/chat/completions",
-      "recordedAt": "2026-07-07T13:51:53.564Z",
+      "recordedAt": "2026-08-24T12:20:34.924Z",
       "request": {
         "body": {
           "kind": "json",
@@ -550,7 +548,7 @@
                       "arguments": "{\"operation\":\"multiply\",\"a\":127,\"b\":49}",
                       "name": "calculate"
                     },
-                    "id": "call_lcOSg1ZwQk3T0mSSMO95zd95",
+                    "id": "call_BMkQ0blzGQeVPEC7pIElPdRs",
                     "type": "function"
                   }
                 ]
@@ -558,7 +556,7 @@
               {
                 "content": "6223",
                 "role": "tool",
-                "tool_call_id": "call_lcOSg1ZwQk3T0mSSMO95zd95"
+                "tool_call_id": "call_BMkQ0blzGQeVPEC7pIElPdRs"
               }
             ],
             "model": "gpt-4o-mini-2024-07-18",
@@ -614,12 +612,12 @@
                 }
               }
             ],
-            "created": 1783432313,
-            "id": "chatcmpl-Dz0VFJX8xIYWEN95h3jytdZxSFwam",
+            "created": 1787574034,
+            "id": "chatcmpl-EGNxCT0hwMHK5XDv3ViqjOdQ3sShs",
             "model": "gpt-4o-mini-2024-07-18",
             "object": "chat.completion",
             "service_tier": "default",
-            "system_fingerprint": "fp_39589d11a4",
+            "system_fingerprint": "fp_0950b7f384",
             "usage": {
               "completion_tokens": 11,
               "completion_tokens_details": {
@@ -641,13 +639,13 @@
           "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
           "alt-svc": "h3=\":443\"; ma=86400",
           "cf-cache-status": "DYNAMIC",
-          "cf-ray": "a17753934cf85b7f-VIE",
+          "cf-ray": "a3024fd2e94a2fd0-IAD",
           "connection": "keep-alive",
           "content-encoding": "gzip",
           "content-type": "application/json",
-          "date": "Tue, 07 Jul 2026 13:51:53 GMT",
+          "date": "Mon, 24 Aug 2026 12:20:34 GMT",
           "openai-organization": "braintrust-data",
-          "openai-processing-ms": "580",
+          "openai-processing-ms": "444",
           "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
           "openai-version": "2020-10-01",
           "server": "cloudflare",
@@ -662,7 +660,7 @@
           "x-ratelimit-remaining-tokens": "149999980",
           "x-ratelimit-reset-requests": "2ms",
           "x-ratelimit-reset-tokens": "0s",
-          "x-request-id": "req_1ae5f475ac244137a0d94e2dc4b59dc2"
+          "x-request-id": "req_149ef64cc6b543eaa8b7c0f602c66bea"
         },
         "status": 200,
         "statusText": "OK"

--- a/e2e/scenarios/wrap-langchain-js-traces/__cassettes__/wrap-langchain-js-traces-v1.cassette.json
+++ b/e2e/scenarios/wrap-langchain-js-traces/__cassettes__/wrap-langchain-js-traces-v1.cassette.json
@@ -2,23 +2,22 @@
   "entries": [
     {
       "callIndex": 0,
-      "id": "fe18d9d8136a510f",
+      "id": "86e93f0671afd2fb",
       "matchKey": "POST api.openai.com/v1/chat/completions",
-      "recordedAt": "2026-07-07T13:51:44.503Z",
+      "recordedAt": "2026-08-24T12:20:22.627Z",
       "request": {
         "body": {
           "kind": "json",
           "value": {
-            "max_tokens": 24,
+            "max_completion_tokens": 512,
             "messages": [
               {
                 "content": "Reply with exactly OK.",
                 "role": "user"
               }
             ],
-            "model": "gpt-4o-mini-2024-07-18",
-            "stream": false,
-            "temperature": 0
+            "model": "gpt-5-nano",
+            "stream": false
           }
         },
         "headers": {},
@@ -33,35 +32,34 @@
               {
                 "finish_reason": "stop",
                 "index": 0,
-                "logprobs": null,
                 "message": {
                   "annotations": [],
-                  "content": "OK.",
+                  "content": "OK",
                   "refusal": null,
                   "role": "assistant"
                 }
               }
             ],
-            "created": 1783432304,
-            "id": "chatcmpl-Dz0V6EQklaoblDQORmNQ9gOlvYMPE",
-            "model": "gpt-4o-mini-2024-07-18",
+            "created": 1787574021,
+            "id": "chatcmpl-EGNwzUCt2YhtMXdmxJ7ea1qvFvjhj",
+            "model": "gpt-5-nano-2025-08-07",
             "object": "chat.completion",
             "service_tier": "default",
-            "system_fingerprint": "fp_f8eef96d28",
+            "system_fingerprint": null,
             "usage": {
-              "completion_tokens": 2,
+              "completion_tokens": 138,
               "completion_tokens_details": {
                 "accepted_prediction_tokens": 0,
                 "audio_tokens": 0,
-                "reasoning_tokens": 0,
+                "reasoning_tokens": 128,
                 "rejected_prediction_tokens": 0
               },
-              "prompt_tokens": 12,
+              "prompt_tokens": 11,
               "prompt_tokens_details": {
                 "audio_tokens": 0,
                 "cached_tokens": 0
               },
-              "total_tokens": 14
+              "total_tokens": 149
             }
           }
         },
@@ -69,13 +67,13 @@
           "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
           "alt-svc": "h3=\":443\"; ma=86400",
           "cf-cache-status": "DYNAMIC",
-          "cf-ray": "a177535aaf935b7f-VIE",
+          "cf-ray": "a3024f76c8462fd0-IAD",
           "connection": "keep-alive",
           "content-encoding": "gzip",
           "content-type": "application/json",
-          "date": "Tue, 07 Jul 2026 13:51:44 GMT",
+          "date": "Mon, 24 Aug 2026 12:20:22 GMT",
           "openai-organization": "braintrust-data",
-          "openai-processing-ms": "563",
+          "openai-processing-ms": "1516",
           "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
           "openai-version": "2020-10-01",
           "server": "cloudflare",
@@ -85,12 +83,12 @@
           "x-content-type-options": "nosniff",
           "x-openai-proxy-wasm": "v0.1",
           "x-ratelimit-limit-requests": "30000",
-          "x-ratelimit-limit-tokens": "150000000",
+          "x-ratelimit-limit-tokens": "180000000",
           "x-ratelimit-remaining-requests": "29999",
-          "x-ratelimit-remaining-tokens": "149999990",
+          "x-ratelimit-remaining-tokens": "179999994",
           "x-ratelimit-reset-requests": "2ms",
           "x-ratelimit-reset-tokens": "0s",
-          "x-request-id": "req_2270ea7d1b8a4bf7b90284096d632ed8"
+          "x-request-id": "req_35266a070f524ced863bd688a979fb9c"
         },
         "status": 200,
         "statusText": "OK"
@@ -100,7 +98,7 @@
       "callIndex": 1,
       "id": "a613a13df4910706",
       "matchKey": "POST api.openai.com/v1/chat/completions",
-      "recordedAt": "2026-07-07T13:51:44.999Z",
+      "recordedAt": "2026-08-24T12:20:23.323Z",
       "request": {
         "body": {
           "kind": "json",
@@ -138,12 +136,12 @@
                 }
               }
             ],
-            "created": 1783432304,
-            "id": "chatcmpl-Dz0V6eqRqsbeHLLtsJ4EDk85y8zt3",
+            "created": 1787574023,
+            "id": "chatcmpl-EGNx181W8ybisMsX1olUNegho55Z4",
             "model": "gpt-4o-mini-2024-07-18",
             "object": "chat.completion",
             "service_tier": "default",
-            "system_fingerprint": "fp_d0469e1700",
+            "system_fingerprint": "fp_fabbcdf5d9",
             "usage": {
               "completion_tokens": 2,
               "completion_tokens_details": {
@@ -165,13 +163,13 @@
           "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
           "alt-svc": "h3=\":443\"; ma=86400",
           "cf-cache-status": "DYNAMIC",
-          "cf-ray": "a177535fbc585b7f-VIE",
+          "cf-ray": "a3024f894d132fd0-IAD",
           "connection": "keep-alive",
           "content-encoding": "gzip",
           "content-type": "application/json",
-          "date": "Tue, 07 Jul 2026 13:51:45 GMT",
+          "date": "Mon, 24 Aug 2026 12:20:23 GMT",
           "openai-organization": "braintrust-data",
-          "openai-processing-ms": "279",
+          "openai-processing-ms": "273",
           "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
           "openai-version": "2020-10-01",
           "server": "cloudflare",
@@ -186,7 +184,7 @@
           "x-ratelimit-remaining-tokens": "149999985",
           "x-ratelimit-reset-requests": "2ms",
           "x-ratelimit-reset-tokens": "0s",
-          "x-request-id": "req_d320f6da8ad04d7a9af39805fe87f35a"
+          "x-request-id": "req_06fe5d162d7f463bb59e50d729b4d20c"
         },
         "status": 200,
         "statusText": "OK"
@@ -196,7 +194,7 @@
       "callIndex": 2,
       "id": "394c0994869e6e1f",
       "matchKey": "POST api.openai.com/v1/chat/completions",
-      "recordedAt": "2026-07-07T13:51:45.825Z",
+      "recordedAt": "2026-08-24T12:20:24.024Z",
       "request": {
         "body": {
           "kind": "json",
@@ -223,15 +221,15 @@
       "response": {
         "body": {
           "chunks": [
-            "data: {\"id\":\"chatcmpl-Dz0V78s7uKW3BNIx4CyloL4zADQYq\",\"object\":\"chat.completion.chunk\",\"created\":1783432305,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"fpaUwlZfB\"}",
-            "data: {\"id\":\"chatcmpl-Dz0V78s7uKW3BNIx4CyloL4zADQYq\",\"object\":\"chat.completion.chunk\",\"created\":1783432305,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"One\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"jlBUw58a\"}",
-            "data: {\"id\":\"chatcmpl-Dz0V78s7uKW3BNIx4CyloL4zADQYq\",\"object\":\"chat.completion.chunk\",\"created\":1783432305,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\",\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"KINnzTc1Ou\"}",
-            "data: {\"id\":\"chatcmpl-Dz0V78s7uKW3BNIx4CyloL4zADQYq\",\"object\":\"chat.completion.chunk\",\"created\":1783432305,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" two\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"vjbiZDB\"}",
-            "data: {\"id\":\"chatcmpl-Dz0V78s7uKW3BNIx4CyloL4zADQYq\",\"object\":\"chat.completion.chunk\",\"created\":1783432305,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\",\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"f40l25UpEq\"}",
-            "data: {\"id\":\"chatcmpl-Dz0V78s7uKW3BNIx4CyloL4zADQYq\",\"object\":\"chat.completion.chunk\",\"created\":1783432305,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" three\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"WTShD\"}",
-            "data: {\"id\":\"chatcmpl-Dz0V78s7uKW3BNIx4CyloL4zADQYq\",\"object\":\"chat.completion.chunk\",\"created\":1783432305,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\".\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"ogrjyNZ6Rc\"}",
-            "data: {\"id\":\"chatcmpl-Dz0V78s7uKW3BNIx4CyloL4zADQYq\",\"object\":\"chat.completion.chunk\",\"created\":1783432305,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"usage\":null,\"obfuscation\":\"jGV2Y\"}",
-            "data: {\"id\":\"chatcmpl-Dz0V78s7uKW3BNIx4CyloL4zADQYq\",\"object\":\"chat.completion.chunk\",\"created\":1783432305,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_85fd54540d\",\"choices\":[],\"usage\":{\"prompt_tokens\":22,\"completion_tokens\":6,\"total_tokens\":28,\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}},\"obfuscation\":\"Ve8rSMia008\"}",
+            "data: {\"id\":\"chatcmpl-EGNx1I8x3YZKvOGhuC0S5biZ26Gwl\",\"object\":\"chat.completion.chunk\",\"created\":1787574023,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"Oj4Hh3j31\"}",
+            "data: {\"id\":\"chatcmpl-EGNx1I8x3YZKvOGhuC0S5biZ26Gwl\",\"object\":\"chat.completion.chunk\",\"created\":1787574023,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"One\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"Il4NOQeI\"}",
+            "data: {\"id\":\"chatcmpl-EGNx1I8x3YZKvOGhuC0S5biZ26Gwl\",\"object\":\"chat.completion.chunk\",\"created\":1787574023,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\",\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"rVAPk2Cs7X\"}",
+            "data: {\"id\":\"chatcmpl-EGNx1I8x3YZKvOGhuC0S5biZ26Gwl\",\"object\":\"chat.completion.chunk\",\"created\":1787574023,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" two\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"sFT4iNt\"}",
+            "data: {\"id\":\"chatcmpl-EGNx1I8x3YZKvOGhuC0S5biZ26Gwl\",\"object\":\"chat.completion.chunk\",\"created\":1787574023,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\",\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"tSa35AR216\"}",
+            "data: {\"id\":\"chatcmpl-EGNx1I8x3YZKvOGhuC0S5biZ26Gwl\",\"object\":\"chat.completion.chunk\",\"created\":1787574023,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" three\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"oXtaZ\"}",
+            "data: {\"id\":\"chatcmpl-EGNx1I8x3YZKvOGhuC0S5biZ26Gwl\",\"object\":\"chat.completion.chunk\",\"created\":1787574023,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\".\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"pfwlwCc1UG\"}",
+            "data: {\"id\":\"chatcmpl-EGNx1I8x3YZKvOGhuC0S5biZ26Gwl\",\"object\":\"chat.completion.chunk\",\"created\":1787574023,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"usage\":null,\"obfuscation\":\"0pszW\"}",
+            "data: {\"id\":\"chatcmpl-EGNx1I8x3YZKvOGhuC0S5biZ26Gwl\",\"object\":\"chat.completion.chunk\",\"created\":1787574023,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_0950b7f384\",\"choices\":[],\"usage\":{\"prompt_tokens\":22,\"completion_tokens\":6,\"total_tokens\":28,\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}},\"obfuscation\":\"kalzk5DmKv4\"}",
             "data: [DONE]"
           ],
           "kind": "sse"
@@ -240,12 +238,12 @@
           "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
           "alt-svc": "h3=\":443\"; ma=86400",
           "cf-cache-status": "DYNAMIC",
-          "cf-ray": "a1775362be435b7f-VIE",
+          "cf-ray": "a3024f8d9d6b2fd0-IAD",
           "connection": "keep-alive",
           "content-type": "text/event-stream; charset=utf-8",
-          "date": "Tue, 07 Jul 2026 13:51:45 GMT",
+          "date": "Mon, 24 Aug 2026 12:20:23 GMT",
           "openai-organization": "braintrust-data",
-          "openai-processing-ms": "485",
+          "openai-processing-ms": "396",
           "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
           "openai-version": "2020-10-01",
           "server": "cloudflare",
@@ -260,7 +258,7 @@
           "x-ratelimit-remaining-tokens": "149999985",
           "x-ratelimit-reset-requests": "2ms",
           "x-ratelimit-reset-tokens": "0s",
-          "x-request-id": "req_b72640ddae9c4197934028a956a8e299"
+          "x-request-id": "req_a0055ad7660e45bb855ae0977d3a9b46"
         },
         "status": 200,
         "statusText": "OK"
@@ -270,7 +268,7 @@
       "callIndex": 3,
       "id": "7f1e5cd685579c33",
       "matchKey": "POST api.openai.com/v1/chat/completions",
-      "recordedAt": "2026-07-07T13:51:46.583Z",
+      "recordedAt": "2026-08-24T12:20:24.773Z",
       "request": {
         "body": {
           "kind": "json",
@@ -332,19 +330,19 @@
                         "arguments": "{\"location\":\"Paris, France\"}",
                         "name": "get_weather"
                       },
-                      "id": "call_ZMXzm3VBY7GK975ZXkNhCEvg",
+                      "id": "call_vFUhlOlK88FODFbm0RCSfovD",
                       "type": "function"
                     }
                   ]
                 }
               }
             ],
-            "created": 1783432306,
-            "id": "chatcmpl-Dz0V8NNUziCYfoQJlVCMBHr0PJT4f",
+            "created": 1787574024,
+            "id": "chatcmpl-EGNx23GX8lOwzBQnZTCKTXwLeUyRG",
             "model": "gpt-4o-mini-2024-07-18",
             "object": "chat.completion",
             "service_tier": "default",
-            "system_fingerprint": "fp_3516695052",
+            "system_fingerprint": "fp_02ae59e84c",
             "usage": {
               "completion_tokens": 16,
               "completion_tokens_details": {
@@ -366,13 +364,13 @@
           "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
           "alt-svc": "h3=\":443\"; ma=86400",
           "cf-cache-status": "DYNAMIC",
-          "cf-ray": "a1775367e9b05b7f-VIE",
+          "cf-ray": "a3024f91fd8b2fd0-IAD",
           "connection": "keep-alive",
           "content-encoding": "gzip",
           "content-type": "application/json",
-          "date": "Tue, 07 Jul 2026 13:51:46 GMT",
+          "date": "Mon, 24 Aug 2026 12:20:24 GMT",
           "openai-organization": "braintrust-data",
-          "openai-processing-ms": "550",
+          "openai-processing-ms": "649",
           "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
           "openai-version": "2020-10-01",
           "server": "cloudflare",
@@ -384,10 +382,10 @@
           "x-ratelimit-limit-requests": "30000",
           "x-ratelimit-limit-tokens": "150000000",
           "x-ratelimit-remaining-requests": "29999",
-          "x-ratelimit-remaining-tokens": "149999980",
+          "x-ratelimit-remaining-tokens": "149999977",
           "x-ratelimit-reset-requests": "2ms",
           "x-ratelimit-reset-tokens": "0s",
-          "x-request-id": "req_ba46554d4f8e462aad3a8d716d7be682"
+          "x-request-id": "req_27d9929b8cfa4c40b969771b87ffd0bf"
         },
         "status": 200,
         "statusText": "OK"
@@ -397,7 +395,7 @@
       "callIndex": 4,
       "id": "92b304bbb4ce5170",
       "matchKey": "POST api.openai.com/v1/chat/completions",
-      "recordedAt": "2026-07-07T13:51:47.333Z",
+      "recordedAt": "2026-08-24T12:20:27.515Z",
       "request": {
         "body": {
           "kind": "json",
@@ -465,19 +463,19 @@
                         "arguments": "{\"operation\":\"multiply\",\"a\":127,\"b\":49}",
                         "name": "calculate"
                       },
-                      "id": "call_CntJIwZg1SsU86VjMiAhxghE",
+                      "id": "call_dXQI5d9UAYuRygDqNMunj2W2",
                       "type": "function"
                     }
                   ]
                 }
               }
             ],
-            "created": 1783432306,
-            "id": "chatcmpl-Dz0V8vlk3If9ZcY24xwDxdq9vdCgB",
+            "created": 1787574027,
+            "id": "chatcmpl-EGNx52wzdb9GL8hdL3YZCMSLvJkQ4",
             "model": "gpt-4o-mini-2024-07-18",
             "object": "chat.completion",
             "service_tier": "default",
-            "system_fingerprint": "fp_39589d11a4",
+            "system_fingerprint": "fp_0950b7f384",
             "usage": {
               "completion_tokens": 21,
               "completion_tokens_details": {
@@ -499,13 +497,13 @@
           "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
           "alt-svc": "h3=\":443\"; ma=86400",
           "cf-cache-status": "DYNAMIC",
-          "cf-ray": "a177536c9c6c5b7f-VIE",
+          "cf-ray": "a3024f969f342fd0-IAD",
           "connection": "keep-alive",
           "content-encoding": "gzip",
           "content-type": "application/json",
-          "date": "Tue, 07 Jul 2026 13:51:47 GMT",
+          "date": "Mon, 24 Aug 2026 12:20:27 GMT",
           "openai-organization": "braintrust-data",
-          "openai-processing-ms": "546",
+          "openai-processing-ms": "729",
           "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
           "openai-version": "2020-10-01",
           "server": "cloudflare",
@@ -517,10 +515,10 @@
           "x-ratelimit-limit-requests": "30000",
           "x-ratelimit-limit-tokens": "150000000",
           "x-ratelimit-remaining-requests": "29999",
-          "x-ratelimit-remaining-tokens": "149999982",
+          "x-ratelimit-remaining-tokens": "149999985",
           "x-ratelimit-reset-requests": "2ms",
           "x-ratelimit-reset-tokens": "0s",
-          "x-request-id": "req_fe27e8d13d524418b6163efb946914e5"
+          "x-request-id": "req_86b70fed7a674d028ec1293c0e2cd0ec"
         },
         "status": 200,
         "statusText": "OK"
@@ -528,9 +526,9 @@
     },
     {
       "callIndex": 5,
-      "id": "8bc1785325a3e2eb",
+      "id": "a57d0dfe4d90c4bd",
       "matchKey": "POST api.openai.com/v1/chat/completions",
-      "recordedAt": "2026-07-07T13:51:48.010Z",
+      "recordedAt": "2026-08-24T12:20:28.216Z",
       "request": {
         "body": {
           "kind": "json",
@@ -550,7 +548,7 @@
                       "arguments": "{\"operation\":\"multiply\",\"a\":127,\"b\":49}",
                       "name": "calculate"
                     },
-                    "id": "call_CntJIwZg1SsU86VjMiAhxghE",
+                    "id": "call_dXQI5d9UAYuRygDqNMunj2W2",
                     "type": "function"
                   }
                 ]
@@ -558,7 +556,7 @@
               {
                 "content": "6223",
                 "role": "tool",
-                "tool_call_id": "call_CntJIwZg1SsU86VjMiAhxghE"
+                "tool_call_id": "call_dXQI5d9UAYuRygDqNMunj2W2"
               }
             ],
             "model": "gpt-4o-mini-2024-07-18",
@@ -614,12 +612,12 @@
                 }
               }
             ],
-            "created": 1783432307,
-            "id": "chatcmpl-Dz0V9XyoV0fvNKHvbEeMY0PoH1SgZ",
+            "created": 1787574027,
+            "id": "chatcmpl-EGNx5rDFm8HaHv7GCMw3OzQyu24L9",
             "model": "gpt-4o-mini-2024-07-18",
             "object": "chat.completion",
             "service_tier": "default",
-            "system_fingerprint": "fp_39589d11a4",
+            "system_fingerprint": "fp_0950b7f384",
             "usage": {
               "completion_tokens": 11,
               "completion_tokens_details": {
@@ -641,13 +639,13 @@
           "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
           "alt-svc": "h3=\":443\"; ma=86400",
           "cf-cache-status": "DYNAMIC",
-          "cf-ray": "a17753714f4d5b7f-VIE",
+          "cf-ray": "a3024fa7be702fd0-IAD",
           "connection": "keep-alive",
           "content-encoding": "gzip",
           "content-type": "application/json",
-          "date": "Tue, 07 Jul 2026 13:51:48 GMT",
+          "date": "Mon, 24 Aug 2026 12:20:28 GMT",
           "openai-organization": "braintrust-data",
-          "openai-processing-ms": "480",
+          "openai-processing-ms": "592",
           "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
           "openai-version": "2020-10-01",
           "server": "cloudflare",
@@ -662,7 +660,7 @@
           "x-ratelimit-remaining-tokens": "149999980",
           "x-ratelimit-reset-requests": "2ms",
           "x-ratelimit-reset-tokens": "0s",
-          "x-request-id": "req_aab3e96626be49eba60ee79ecac78e4d"
+          "x-request-id": "req_80ec4ce95cf14b989fddb3c82140dab8"
         },
         "status": 200,
         "statusText": "OK"

--- a/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1-latest.span-tree.json
+++ b/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1-latest.span-tree.json
@@ -44,33 +44,17 @@
                         ],
                         "kwargs": {
                           "additional_kwargs": {},
-                          "content": "OK.",
+                          "content": "OK",
                           "id": "<span:1>",
                           "invalid_tool_calls": [],
                           "response_metadata": {
                             "finish_reason": "stop",
-                            "model_name": "gpt-4o-mini-2024-07-18",
+                            "model_name": "gpt-5-nano-2025-08-07",
                             "model_provider": "openai",
-                            "system_fingerprint": "<system_fingerprint>",
                             "tokenUsage": {
-                              "completionTokens": 2,
-                              "promptTokens": 12,
-                              "totalTokens": 14
-                            },
-                            "usage": {
-                              "completion_tokens": 2,
-                              "completion_tokens_details": {
-                                "accepted_prediction_tokens": 0,
-                                "audio_tokens": 0,
-                                "reasoning_tokens": 0,
-                                "rejected_prediction_tokens": 0
-                              },
-                              "prompt_tokens": 12,
-                              "prompt_tokens_details": {
-                                "audio_tokens": 0,
-                                "cached_tokens": 0
-                              },
-                              "total_tokens": 14
+                              "completionTokens": 266,
+                              "promptTokens": 11,
+                              "totalTokens": 277
                             }
                           },
                           "tool_calls": [],
@@ -80,27 +64,27 @@
                               "audio": 0,
                               "cache_read": 0
                             },
-                            "input_tokens": 12,
+                            "input_tokens": 11,
                             "output_token_details": {
                               "audio": 0,
-                              "reasoning": 0
+                              "reasoning": 256
                             },
-                            "output_tokens": 2,
-                            "total_tokens": 14
+                            "output_tokens": 266,
+                            "total_tokens": 277
                           }
                         },
                         "lc": 1,
                         "type": "constructor"
                       },
-                      "text": "OK."
+                      "text": "OK"
                     }
                   ]
                 ],
                 "llmOutput": {
                   "tokenUsage": {
-                    "completionTokens": 2,
-                    "promptTokens": 12,
-                    "totalTokens": 14
+                    "completionTokens": 266,
+                    "promptTokens": 11,
+                    "totalTokens": 277
                   }
                 }
               },
@@ -111,24 +95,21 @@
                   "sdk_language": "javascript"
                 },
                 "invocation_params": {
-                  "max_tokens": 24,
-                  "model": "gpt-4o-mini-2024-07-18",
-                  "stream": false,
-                  "temperature": 0
+                  "max_completion_tokens": 512,
+                  "model": "gpt-5-nano",
+                  "stream": false
                 },
                 "metadata": {
                   "ls_integration": "langchain_chat_model",
-                  "ls_max_tokens": 24,
-                  "ls_model_name": "gpt-4o-mini-2024-07-18",
+                  "ls_model_name": "gpt-5-nano",
                   "ls_model_type": "chat",
                   "ls_provider": "openai",
-                  "ls_temperature": 0,
                   "versions": {
                     "@langchain/core": "1.2.1",
                     "@langchain/openai": "1.5.3"
                   }
                 },
-                "model": "gpt-4o-mini-2024-07-18",
+                "model": "gpt-5-nano-2025-08-07",
                 "options": {},
                 "run_id": "<uuid:1>",
                 "serialized": {
@@ -139,16 +120,15 @@
                     "ChatOpenAI"
                   ],
                   "kwargs": {
-                    "max_tokens": 24,
-                    "model": "gpt-4o-mini-2024-07-18",
+                    "max_tokens": 512,
+                    "model": "gpt-5-nano",
                     "openai_api_key": {
                       "id": [
                         "OPENAI_API_KEY"
                       ],
                       "lc": 1,
                       "type": "secret"
-                    },
-                    "temperature": 0
+                    }
                   },
                   "lc": 1,
                   "type": "constructor"
@@ -156,11 +136,11 @@
                 "tags": []
               },
               "metrics": {
-                "completion_reasoning_tokens": 0,
-                "completion_tokens": 2,
+                "completion_reasoning_tokens": 256,
+                "completion_tokens": 266,
                 "prompt_cached_tokens": 0,
-                "prompt_tokens": 12,
-                "tokens": 14
+                "prompt_tokens": 11,
+                "tokens": 277
               }
             }
           ],
@@ -1301,7 +1281,7 @@
                       "additional_kwargs": {},
                       "content": "6223",
                       "response_metadata": {},
-                      "tool_call_id": "call_lcOSg1ZwQk3T0mSSMO95zd95"
+                      "tool_call_id": "call_BMkQ0blzGQeVPEC7pIElPdRs"
                     },
                     "lc": 1,
                     "type": "constructor"

--- a/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1-latest.span-tree.json
+++ b/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1-latest.span-tree.json
@@ -156,6 +156,7 @@
                 "tags": []
               },
               "metrics": {
+                "completion_reasoning_tokens": 0,
                 "completion_tokens": 2,
                 "prompt_cached_tokens": 0,
                 "prompt_tokens": 12,
@@ -422,6 +423,7 @@
                     ]
                   },
                   "metrics": {
+                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 2,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 18,
@@ -742,6 +744,7 @@
                 "tags": []
               },
               "metrics": {
+                "completion_reasoning_tokens": 0,
                 "completion_tokens": 6,
                 "prompt_cached_tokens": 0,
                 "prompt_tokens": 22,
@@ -974,6 +977,7 @@
                 "tags": []
               },
               "metrics": {
+                "completion_reasoning_tokens": 0,
                 "completion_tokens": 16,
                 "prompt_cached_tokens": 0,
                 "prompt_tokens": 72,
@@ -1233,6 +1237,7 @@
                 "tags": []
               },
               "metrics": {
+                "completion_reasoning_tokens": 0,
                 "completion_tokens": 21,
                 "prompt_cached_tokens": 0,
                 "prompt_tokens": 76,
@@ -1503,6 +1508,7 @@
                 "tags": []
               },
               "metrics": {
+                "completion_reasoning_tokens": 0,
                 "completion_tokens": 11,
                 "prompt_cached_tokens": 0,
                 "prompt_tokens": 106,

--- a/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1-latest.span-tree.txt
+++ b/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1-latest.span-tree.txt
@@ -43,33 +43,17 @@ span_tree:
     │                 ],
     │                 "kwargs": {
     │                   "additional_kwargs": {},
-    │                   "content": "OK.",
+    │                   "content": "OK",
     │                   "id": "<span:1>",
     │                   "invalid_tool_calls": [],
     │                   "response_metadata": {
     │                     "finish_reason": "stop",
-    │                     "model_name": "gpt-4o-mini-2024-07-18",
+    │                     "model_name": "gpt-5-nano-2025-08-07",
     │                     "model_provider": "openai",
-    │                     "system_fingerprint": "<system_fingerprint>",
     │                     "tokenUsage": {
-    │                       "completionTokens": 2,
-    │                       "promptTokens": 12,
-    │                       "totalTokens": 14
-    │                     },
-    │                     "usage": {
-    │                       "completion_tokens": 2,
-    │                       "completion_tokens_details": {
-    │                         "accepted_prediction_tokens": 0,
-    │                         "audio_tokens": 0,
-    │                         "reasoning_tokens": 0,
-    │                         "rejected_prediction_tokens": 0
-    │                       },
-    │                       "prompt_tokens": 12,
-    │                       "prompt_tokens_details": {
-    │                         "audio_tokens": 0,
-    │                         "cached_tokens": 0
-    │                       },
-    │                       "total_tokens": 14
+    │                       "completionTokens": 266,
+    │                       "promptTokens": 11,
+    │                       "totalTokens": 277
     │                     }
     │                   },
     │                   "tool_calls": [],
@@ -79,27 +63,27 @@ span_tree:
     │                       "audio": 0,
     │                       "cache_read": 0
     │                     },
-    │                     "input_tokens": 12,
+    │                     "input_tokens": 11,
     │                     "output_token_details": {
     │                       "audio": 0,
-    │                       "reasoning": 0
+    │                       "reasoning": 256
     │                     },
-    │                     "output_tokens": 2,
-    │                     "total_tokens": 14
+    │                     "output_tokens": 266,
+    │                     "total_tokens": 277
     │                   }
     │                 },
     │                 "lc": 1,
     │                 "type": "constructor"
     │               },
-    │               "text": "OK."
+    │               "text": "OK"
     │             }
     │           ]
     │         ],
     │         "llmOutput": {
     │           "tokenUsage": {
-    │             "completionTokens": 2,
-    │             "promptTokens": 12,
-    │             "totalTokens": 14
+    │             "completionTokens": 266,
+    │             "promptTokens": 11,
+    │             "totalTokens": 277
     │           }
     │         }
     │       }
@@ -110,24 +94,21 @@ span_tree:
     │           "sdk_language": "javascript"
     │         },
     │         "invocation_params": {
-    │           "max_tokens": 24,
-    │           "model": "gpt-4o-mini-2024-07-18",
-    │           "stream": false,
-    │           "temperature": 0
+    │           "max_completion_tokens": 512,
+    │           "model": "gpt-5-nano",
+    │           "stream": false
     │         },
     │         "metadata": {
     │           "ls_integration": "langchain_chat_model",
-    │           "ls_max_tokens": 24,
-    │           "ls_model_name": "gpt-4o-mini-2024-07-18",
+    │           "ls_model_name": "gpt-5-nano",
     │           "ls_model_type": "chat",
     │           "ls_provider": "openai",
-    │           "ls_temperature": 0,
     │           "versions": {
     │             "@langchain/core": "1.2.1",
     │             "@langchain/openai": "1.5.3"
     │           }
     │         },
-    │         "model": "gpt-4o-mini-2024-07-18",
+    │         "model": "gpt-5-nano-2025-08-07",
     │         "options": {},
     │         "run_id": "<uuid:1>",
     │         "serialized": {
@@ -138,16 +119,15 @@ span_tree:
     │             "ChatOpenAI"
     │           ],
     │           "kwargs": {
-    │             "max_tokens": 24,
-    │             "model": "gpt-4o-mini-2024-07-18",
+    │             "max_tokens": 512,
+    │             "model": "gpt-5-nano",
     │             "openai_api_key": {
     │               "id": [
     │                 "OPENAI_API_KEY"
     │               ],
     │               "lc": 1,
     │               "type": "secret"
-    │             },
-    │             "temperature": 0
+    │             }
     │           },
     │           "lc": 1,
     │           "type": "constructor"
@@ -155,11 +135,11 @@ span_tree:
     │         "tags": []
     │       }
     │       metrics: {
-    │         "completion_reasoning_tokens": 0,
-    │         "completion_tokens": 2,
+    │         "completion_reasoning_tokens": 256,
+    │         "completion_tokens": 266,
     │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 12,
-    │         "tokens": 14
+    │         "prompt_tokens": 11,
+    │         "tokens": 277
     │       }
     ├── langchain-chain-operation
     │   metadata: {
@@ -1255,7 +1235,7 @@ span_tree:
                     "additional_kwargs": {},
                     "content": "6223",
                     "response_metadata": {},
-                    "tool_call_id": "call_lcOSg1ZwQk3T0mSSMO95zd95"
+                    "tool_call_id": "call_BMkQ0blzGQeVPEC7pIElPdRs"
                   },
                   "lc": 1,
                   "type": "constructor"

--- a/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1-latest.span-tree.txt
+++ b/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1-latest.span-tree.txt
@@ -155,6 +155,7 @@ span_tree:
     │         "tags": []
     │       }
     │       metrics: {
+    │         "completion_reasoning_tokens": 0,
     │         "completion_tokens": 2,
     │         "prompt_cached_tokens": 0,
     │         "prompt_tokens": 12,
@@ -553,6 +554,7 @@ span_tree:
     │             ]
     │           }
     │           metrics: {
+    │             "completion_reasoning_tokens": 0,
     │             "completion_tokens": 2,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 18,
@@ -716,6 +718,7 @@ span_tree:
     │         "tags": []
     │       }
     │       metrics: {
+    │         "completion_reasoning_tokens": 0,
     │         "completion_tokens": 6,
     │         "prompt_cached_tokens": 0,
     │         "prompt_tokens": 22,
@@ -940,6 +943,7 @@ span_tree:
     │         "tags": []
     │       }
     │       metrics: {
+    │         "completion_reasoning_tokens": 0,
     │         "completion_tokens": 16,
     │         "prompt_cached_tokens": 0,
     │         "prompt_tokens": 72,
@@ -1191,6 +1195,7 @@ span_tree:
         │     "tags": []
         │   }
         │   metrics: {
+        │     "completion_reasoning_tokens": 0,
         │     "completion_tokens": 21,
         │     "prompt_cached_tokens": 0,
         │     "prompt_tokens": 76,
@@ -1457,6 +1462,7 @@ span_tree:
               "tags": []
             }
             metrics: {
+              "completion_reasoning_tokens": 0,
               "completion_tokens": 11,
               "prompt_cached_tokens": 0,
               "prompt_tokens": 106,

--- a/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1.span-tree.json
+++ b/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1.span-tree.json
@@ -156,6 +156,7 @@
                 "tags": []
               },
               "metrics": {
+                "completion_reasoning_tokens": 0,
                 "completion_tokens": 2,
                 "prompt_cached_tokens": 0,
                 "prompt_tokens": 12,
@@ -422,6 +423,7 @@
                     ]
                   },
                   "metrics": {
+                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 2,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 18,
@@ -742,6 +744,7 @@
                 "tags": []
               },
               "metrics": {
+                "completion_reasoning_tokens": 0,
                 "completion_tokens": 6,
                 "prompt_cached_tokens": 0,
                 "prompt_tokens": 22,
@@ -974,6 +977,7 @@
                 "tags": []
               },
               "metrics": {
+                "completion_reasoning_tokens": 0,
                 "completion_tokens": 16,
                 "prompt_cached_tokens": 0,
                 "prompt_tokens": 72,
@@ -1233,6 +1237,7 @@
                 "tags": []
               },
               "metrics": {
+                "completion_reasoning_tokens": 0,
                 "completion_tokens": 21,
                 "prompt_cached_tokens": 0,
                 "prompt_tokens": 76,
@@ -1503,6 +1508,7 @@
                 "tags": []
               },
               "metrics": {
+                "completion_reasoning_tokens": 0,
                 "completion_tokens": 11,
                 "prompt_cached_tokens": 0,
                 "prompt_tokens": 106,

--- a/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1.span-tree.json
+++ b/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1.span-tree.json
@@ -44,33 +44,17 @@
                         ],
                         "kwargs": {
                           "additional_kwargs": {},
-                          "content": "OK.",
+                          "content": "OK",
                           "id": "<span:1>",
                           "invalid_tool_calls": [],
                           "response_metadata": {
                             "finish_reason": "stop",
-                            "model_name": "gpt-4o-mini-2024-07-18",
+                            "model_name": "gpt-5-nano-2025-08-07",
                             "model_provider": "openai",
-                            "system_fingerprint": "<system_fingerprint>",
                             "tokenUsage": {
-                              "completionTokens": 2,
-                              "promptTokens": 12,
-                              "totalTokens": 14
-                            },
-                            "usage": {
-                              "completion_tokens": 2,
-                              "completion_tokens_details": {
-                                "accepted_prediction_tokens": 0,
-                                "audio_tokens": 0,
-                                "reasoning_tokens": 0,
-                                "rejected_prediction_tokens": 0
-                              },
-                              "prompt_tokens": 12,
-                              "prompt_tokens_details": {
-                                "audio_tokens": 0,
-                                "cached_tokens": 0
-                              },
-                              "total_tokens": 14
+                              "completionTokens": 138,
+                              "promptTokens": 11,
+                              "totalTokens": 149
                             }
                           },
                           "tool_calls": [],
@@ -80,27 +64,27 @@
                               "audio": 0,
                               "cache_read": 0
                             },
-                            "input_tokens": 12,
+                            "input_tokens": 11,
                             "output_token_details": {
                               "audio": 0,
-                              "reasoning": 0
+                              "reasoning": 128
                             },
-                            "output_tokens": 2,
-                            "total_tokens": 14
+                            "output_tokens": 138,
+                            "total_tokens": 149
                           }
                         },
                         "lc": 1,
                         "type": "constructor"
                       },
-                      "text": "OK."
+                      "text": "OK"
                     }
                   ]
                 ],
                 "llmOutput": {
                   "tokenUsage": {
-                    "completionTokens": 2,
-                    "promptTokens": 12,
-                    "totalTokens": 14
+                    "completionTokens": 138,
+                    "promptTokens": 11,
+                    "totalTokens": 149
                   }
                 }
               },
@@ -111,24 +95,21 @@
                   "sdk_language": "javascript"
                 },
                 "invocation_params": {
-                  "max_tokens": 24,
-                  "model": "gpt-4o-mini-2024-07-18",
-                  "stream": false,
-                  "temperature": 0
+                  "max_completion_tokens": 512,
+                  "model": "gpt-5-nano",
+                  "stream": false
                 },
                 "metadata": {
                   "ls_integration": "langchain_chat_model",
-                  "ls_max_tokens": 24,
-                  "ls_model_name": "gpt-4o-mini-2024-07-18",
+                  "ls_model_name": "gpt-5-nano",
                   "ls_model_type": "chat",
                   "ls_provider": "openai",
-                  "ls_temperature": 0,
                   "versions": {
                     "@langchain/core": "1.2.1",
                     "@langchain/openai": "1.3.0"
                   }
                 },
-                "model": "gpt-4o-mini-2024-07-18",
+                "model": "gpt-5-nano-2025-08-07",
                 "options": {},
                 "run_id": "<uuid:1>",
                 "serialized": {
@@ -139,16 +120,15 @@
                     "ChatOpenAI"
                   ],
                   "kwargs": {
-                    "max_tokens": 24,
-                    "model": "gpt-4o-mini-2024-07-18",
+                    "max_tokens": 512,
+                    "model": "gpt-5-nano",
                     "openai_api_key": {
                       "id": [
                         "OPENAI_API_KEY"
                       ],
                       "lc": 1,
                       "type": "secret"
-                    },
-                    "temperature": 0
+                    }
                   },
                   "lc": 1,
                   "type": "constructor"
@@ -156,11 +136,11 @@
                 "tags": []
               },
               "metrics": {
-                "completion_reasoning_tokens": 0,
-                "completion_tokens": 2,
+                "completion_reasoning_tokens": 128,
+                "completion_tokens": 138,
                 "prompt_cached_tokens": 0,
-                "prompt_tokens": 12,
-                "tokens": 14
+                "prompt_tokens": 11,
+                "tokens": 149
               }
             }
           ],
@@ -1301,7 +1281,7 @@
                       "additional_kwargs": {},
                       "content": "6223",
                       "response_metadata": {},
-                      "tool_call_id": "call_CntJIwZg1SsU86VjMiAhxghE"
+                      "tool_call_id": "call_dXQI5d9UAYuRygDqNMunj2W2"
                     },
                     "lc": 1,
                     "type": "constructor"

--- a/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1.span-tree.txt
+++ b/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1.span-tree.txt
@@ -43,33 +43,17 @@ span_tree:
     │                 ],
     │                 "kwargs": {
     │                   "additional_kwargs": {},
-    │                   "content": "OK.",
+    │                   "content": "OK",
     │                   "id": "<span:1>",
     │                   "invalid_tool_calls": [],
     │                   "response_metadata": {
     │                     "finish_reason": "stop",
-    │                     "model_name": "gpt-4o-mini-2024-07-18",
+    │                     "model_name": "gpt-5-nano-2025-08-07",
     │                     "model_provider": "openai",
-    │                     "system_fingerprint": "<system_fingerprint>",
     │                     "tokenUsage": {
-    │                       "completionTokens": 2,
-    │                       "promptTokens": 12,
-    │                       "totalTokens": 14
-    │                     },
-    │                     "usage": {
-    │                       "completion_tokens": 2,
-    │                       "completion_tokens_details": {
-    │                         "accepted_prediction_tokens": 0,
-    │                         "audio_tokens": 0,
-    │                         "reasoning_tokens": 0,
-    │                         "rejected_prediction_tokens": 0
-    │                       },
-    │                       "prompt_tokens": 12,
-    │                       "prompt_tokens_details": {
-    │                         "audio_tokens": 0,
-    │                         "cached_tokens": 0
-    │                       },
-    │                       "total_tokens": 14
+    │                       "completionTokens": 138,
+    │                       "promptTokens": 11,
+    │                       "totalTokens": 149
     │                     }
     │                   },
     │                   "tool_calls": [],
@@ -79,27 +63,27 @@ span_tree:
     │                       "audio": 0,
     │                       "cache_read": 0
     │                     },
-    │                     "input_tokens": 12,
+    │                     "input_tokens": 11,
     │                     "output_token_details": {
     │                       "audio": 0,
-    │                       "reasoning": 0
+    │                       "reasoning": 128
     │                     },
-    │                     "output_tokens": 2,
-    │                     "total_tokens": 14
+    │                     "output_tokens": 138,
+    │                     "total_tokens": 149
     │                   }
     │                 },
     │                 "lc": 1,
     │                 "type": "constructor"
     │               },
-    │               "text": "OK."
+    │               "text": "OK"
     │             }
     │           ]
     │         ],
     │         "llmOutput": {
     │           "tokenUsage": {
-    │             "completionTokens": 2,
-    │             "promptTokens": 12,
-    │             "totalTokens": 14
+    │             "completionTokens": 138,
+    │             "promptTokens": 11,
+    │             "totalTokens": 149
     │           }
     │         }
     │       }
@@ -110,24 +94,21 @@ span_tree:
     │           "sdk_language": "javascript"
     │         },
     │         "invocation_params": {
-    │           "max_tokens": 24,
-    │           "model": "gpt-4o-mini-2024-07-18",
-    │           "stream": false,
-    │           "temperature": 0
+    │           "max_completion_tokens": 512,
+    │           "model": "gpt-5-nano",
+    │           "stream": false
     │         },
     │         "metadata": {
     │           "ls_integration": "langchain_chat_model",
-    │           "ls_max_tokens": 24,
-    │           "ls_model_name": "gpt-4o-mini-2024-07-18",
+    │           "ls_model_name": "gpt-5-nano",
     │           "ls_model_type": "chat",
     │           "ls_provider": "openai",
-    │           "ls_temperature": 0,
     │           "versions": {
     │             "@langchain/core": "1.2.1",
     │             "@langchain/openai": "1.3.0"
     │           }
     │         },
-    │         "model": "gpt-4o-mini-2024-07-18",
+    │         "model": "gpt-5-nano-2025-08-07",
     │         "options": {},
     │         "run_id": "<uuid:1>",
     │         "serialized": {
@@ -138,16 +119,15 @@ span_tree:
     │             "ChatOpenAI"
     │           ],
     │           "kwargs": {
-    │             "max_tokens": 24,
-    │             "model": "gpt-4o-mini-2024-07-18",
+    │             "max_tokens": 512,
+    │             "model": "gpt-5-nano",
     │             "openai_api_key": {
     │               "id": [
     │                 "OPENAI_API_KEY"
     │               ],
     │               "lc": 1,
     │               "type": "secret"
-    │             },
-    │             "temperature": 0
+    │             }
     │           },
     │           "lc": 1,
     │           "type": "constructor"
@@ -155,11 +135,11 @@ span_tree:
     │         "tags": []
     │       }
     │       metrics: {
-    │         "completion_reasoning_tokens": 0,
-    │         "completion_tokens": 2,
+    │         "completion_reasoning_tokens": 128,
+    │         "completion_tokens": 138,
     │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 12,
-    │         "tokens": 14
+    │         "prompt_tokens": 11,
+    │         "tokens": 149
     │       }
     ├── langchain-chain-operation
     │   metadata: {
@@ -1255,7 +1235,7 @@ span_tree:
                     "additional_kwargs": {},
                     "content": "6223",
                     "response_metadata": {},
-                    "tool_call_id": "call_CntJIwZg1SsU86VjMiAhxghE"
+                    "tool_call_id": "call_dXQI5d9UAYuRygDqNMunj2W2"
                   },
                   "lc": 1,
                   "type": "constructor"

--- a/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1.span-tree.txt
+++ b/e2e/scenarios/wrap-langchain-js-traces/__snapshots__/wrap-langchain-js-traces-v1.span-tree.txt
@@ -155,6 +155,7 @@ span_tree:
     │         "tags": []
     │       }
     │       metrics: {
+    │         "completion_reasoning_tokens": 0,
     │         "completion_tokens": 2,
     │         "prompt_cached_tokens": 0,
     │         "prompt_tokens": 12,
@@ -553,6 +554,7 @@ span_tree:
     │             ]
     │           }
     │           metrics: {
+    │             "completion_reasoning_tokens": 0,
     │             "completion_tokens": 2,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 18,
@@ -716,6 +718,7 @@ span_tree:
     │         "tags": []
     │       }
     │       metrics: {
+    │         "completion_reasoning_tokens": 0,
     │         "completion_tokens": 6,
     │         "prompt_cached_tokens": 0,
     │         "prompt_tokens": 22,
@@ -940,6 +943,7 @@ span_tree:
     │         "tags": []
     │       }
     │       metrics: {
+    │         "completion_reasoning_tokens": 0,
     │         "completion_tokens": 16,
     │         "prompt_cached_tokens": 0,
     │         "prompt_tokens": 72,
@@ -1191,6 +1195,7 @@ span_tree:
         │     "tags": []
         │   }
         │   metrics: {
+        │     "completion_reasoning_tokens": 0,
         │     "completion_tokens": 21,
         │     "prompt_cached_tokens": 0,
         │     "prompt_tokens": 76,
@@ -1457,6 +1462,7 @@ span_tree:
               "tags": []
             }
             metrics: {
+              "completion_reasoning_tokens": 0,
               "completion_tokens": 11,
               "prompt_cached_tokens": 0,
               "prompt_tokens": 106,

--- a/e2e/scenarios/wrap-langchain-js-traces/assertions.ts
+++ b/e2e/scenarios/wrap-langchain-js-traces/assertions.ts
@@ -72,6 +72,7 @@ export function assertLangchainTraces(options: {
   );
   expect(invokeSpan).toBeDefined();
   expect(invokeSpan?.span.type).toBe("llm");
+  expect(invokeSpan?.metrics?.completion_reasoning_tokens).toBeGreaterThan(0);
 
   const chainChildren = findChildSpans(
     options.capturedEvents,

--- a/e2e/scenarios/wrap-langchain-js-traces/scenario.ts
+++ b/e2e/scenarios/wrap-langchain-js-traces/scenario.ts
@@ -12,6 +12,7 @@ import {
 import { runMain } from "../../helpers/scenario-runtime";
 
 const OPENAI_MODEL = "gpt-4o-mini-2024-07-18";
+const OPENAI_REASONING_MODEL = "gpt-5-nano";
 
 runMain(async () => {
   const { AIMessage, HumanMessage, ToolMessage } = await import(
@@ -33,9 +34,8 @@ runMain(async () => {
 
       await runOperation("langchain-invoke-operation", "invoke", async () => {
         const model = new ChatOpenAI({
-          model: OPENAI_MODEL,
-          maxTokens: 24,
-          temperature: 0,
+          model: OPENAI_REASONING_MODEL,
+          maxTokens: 512,
           callbacks: [handler],
         });
         await model.invoke([new HumanMessage("Reply with exactly OK.")]);

--- a/js/src/wrappers/langchain/callback-handler.test.ts
+++ b/js/src/wrappers/langchain/callback-handler.test.ts
@@ -128,4 +128,66 @@ describe("BraintrustLangChainCallbackHandler metrics", () => {
       tokens: 12,
     });
   });
+
+  it("preserves reasoning metrics from message usage metadata", async () => {
+    const { endLog } = await finishChatModelRun({
+      generations: [
+        [
+          {
+            message: {
+              usage_metadata: {
+                input_tokens: 10,
+                output_tokens: 20,
+                total_tokens: 30,
+                output_token_details: {
+                  reasoning: 16,
+                },
+              },
+            },
+          },
+        ],
+      ],
+    });
+
+    expect(endLog.metrics).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 20,
+      completion_reasoning_tokens: 16,
+      tokens: 30,
+    });
+  });
+
+  it("reports zero reasoning tokens rather than dropping the field", async () => {
+    const { endLog } = await finishChatModelRun({
+      generations: [
+        [
+          {
+            message: {
+              usage_metadata: {
+                input_tokens: 12,
+                output_tokens: 2,
+                total_tokens: 14,
+                input_token_details: {
+                  audio: 0,
+                  cache_read: 0,
+                },
+                output_token_details: {
+                  audio: 0,
+                  reasoning: 0,
+                },
+              },
+            },
+          },
+        ],
+      ],
+    });
+
+    expect(endLog.metrics).toEqual({
+      prompt_tokens: 12,
+      completion_tokens: 2,
+      prompt_cached_tokens: 0,
+      completion_reasoning_tokens: 0,
+      tokens: 14,
+    });
+  });
 });

--- a/js/src/wrappers/langchain/callback-handler.ts
+++ b/js/src/wrappers/langchain/callback-handler.ts
@@ -523,6 +523,7 @@ function getMetricsFromResponse(
     }
 
     const inputTokenDetails = usageMetadata.input_token_details;
+    const outputTokenDetails = usageMetadata.output_token_details;
     return normalizeTokenMetrics({
       total_tokens: usageMetadata.total_tokens,
       prompt_tokens: usageMetadata.input_tokens,
@@ -532,6 +533,9 @@ function getMetricsFromResponse(
         : undefined,
       prompt_cached_tokens: isRecord(inputTokenDetails)
         ? inputTokenDetails.cache_read
+        : undefined,
+      completion_reasoning_tokens: isRecord(outputTokenDetails)
+        ? outputTokenDetails.reasoning
         : undefined,
     });
   }


### PR DESCRIPTION
LangChain's `UsageMetadata` carries `output_token_details.reasoning`, and nothing in `js/src` or
`integrations` read it. `completion_tokens` covers the spend, so what was lost is the breakdown:
no way to see how much of a reasoning model's output went to thinking, on any LangChain or
LangGraph span.

Mapped `reasoning` only. `js/src/wrappers/mastra.ts:164-172` settles the scope, picking up the
non-modality detail fields (`cacheRead`, `cacheWrite`, `reasoning`) and leaving the modality ones
alone. `OutputTokenDetails` also carries `audio`, `image`, `video`, `document` and `text` through
`ModalitiesTokenDetails`; the input side drops its copies too, so those are a separate change.

Zero is recorded, not dropped, matching `prompt_cached_tokens: 0` in the existing snapshots.

`js/src/instrumentation/plugins/langsmith-plugin.ts:456` has the same gap. Left alone because
#2386 is moving that tree.

Snapshot churn is 30 added lines across 10 files, every one `completion_reasoning_tokens`, both
sides of each span-tree pair regenerated, no deletions.

Ran `pnpm test` in `js/` (1648 passed), `check:typings`, `lint`, and `test:e2e:update` then
`test:e2e` once each, not twice. On that assert pass `scenarios/git-metadata` timed out at 30s
under parallel load. It passes in isolation here in 1.19s and on `main` in 1.20s, and the two
scenarios this change touches pass, so I read it as local contention. Worth confirming on CI.

Both new unit tests fail against `main` on assertions.
