### PR TITLE
chore: Pass on attachments in e2e test prod forwarding

### DIFF
--- a/e2e/helpers/mock-braintrust-server.ts
+++ b/e2e/helpers/mock-braintrust-server.ts
@@ -682,6 +682,16 @@ export async function startMockBraintrustServer(
           capturedRequest.method === "POST" &&
           capturedRequest.path === "/attachment"
         ) {
+          if (prodForwarding) {
+            const forwardedResponse = await forwardProdRequest(capturedRequest);
+            respondJson(
+              res,
+              200,
+              (await forwardedResponse.json()) as JsonValue,
+            );
+            return;
+          }
+
           const key =
             isRecord(capturedRequest.jsonBody) &&
             typeof capturedRequest.jsonBody.key === "string"
@@ -706,6 +716,11 @@ export async function startMockBraintrustServer(
           capturedRequest.method === "POST" &&
           capturedRequest.path === "/attachment/status"
         ) {
+          if (prodForwarding) {
+            await forwardProdRequest(capturedRequest, {
+              drainResponseBody: true,
+            });
+          }
           respondJson(res, 200, { ok: true });
           return;
         }


### PR DESCRIPTION
For the e2e test traces to braintrust we didn't capture attachments properly