### PR TITLE
fix: Fix OTEL trace context propagation race

### DIFF
--- a/.changeset/trace-context-propagation-race.md
+++ b/.changeset/trace-context-propagation-race.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix: Fix OTEL trace context propagation race

--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -19,8 +19,10 @@ import {
   _exportsForTestingOnly,
   BraintrustState,
   initLogger,
+  injectTraceContext,
   TestBackgroundLogger,
 } from "./logger";
+import { parseBaggage } from "./propagation";
 import { configureNode } from "./node/config";
 import type { ProgressReporter } from "./reporters/types";
 import { InternalAbortError } from "./util";
@@ -2129,6 +2131,64 @@ test("Eval with parent flushes evaluator state, not global state", async () => {
 
   _exportsForTestingOnly.clearTestBackgroundLogger();
   _exportsForTestingOnly.simulateLogoutForTests();
+});
+
+// Regression: the experiment id resolves asynchronously (POST
+// /api/experiment/register), but `Span.inject` reads it synchronously to build
+// the `braintrust.parent` baggage entry. If Eval starts tasks before the id
+// lands, the first task propagates trace identity with no destination and the
+// receiving process silently starts a fresh local trace.
+test("Eval resolves the experiment id before tasks run so injected context is routable", async () => {
+  const state = await _exportsForTestingOnly.simulateLoginForTests();
+  vi.spyOn(state, "login").mockResolvedValue(state as never);
+  vi.spyOn(_exportsForTestingOnly.isomorph, "getRepoInfo").mockResolvedValue(
+    undefined,
+  );
+  vi.spyOn(
+    _exportsForTestingOnly.isomorph,
+    "getPastNAncestors",
+  ).mockResolvedValue([]);
+  vi.spyOn(state.appConn(), "post_json").mockResolvedValue({
+    project: { id: "project-id", name: "test-inject-project" },
+    experiment: {
+      id: "experiment-id",
+      project_id: "project-id",
+      name: "test-inject-experiment",
+      public: false,
+    },
+  });
+  _exportsForTestingOnly.useTestBackgroundLogger();
+
+  const carriers: Record<string, string>[] = [];
+
+  await Eval(
+    "test-inject-project",
+    {
+      data: [{ input: 1 }, { input: 2 }],
+      task: (input: number) => {
+        carriers.push(injectTraceContext());
+        return input * 2;
+      },
+      scores: [],
+      state,
+      // Keep the run hermetic: score summarization is a separate server round trip.
+      summarizeScores: false,
+    },
+    { returnResults: false },
+  );
+
+  expect(carriers).toHaveLength(2);
+  for (const carrier of carriers) {
+    expect(carrier["traceparent"]).toBeDefined();
+    // The first task must carry the parent, not just the later ones.
+    expect(parseBaggage(carrier["baggage"])["braintrust.parent"]).toBe(
+      "experiment_id:experiment-id",
+    );
+  }
+
+  _exportsForTestingOnly.clearTestBackgroundLogger();
+  _exportsForTestingOnly.simulateLogoutForTests();
+  vi.restoreAllMocks();
 });
 
 test("classifier-only evaluator populates classifications field", async () => {

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -815,14 +815,13 @@ export async function Eval<
       { disabled: Boolean(options.parent || options.noSendLogs) },
     );
 
-    // Ensure experiment ID is resolved before tasks start for OTEL parent attribute support
-    // The Experiment constructor starts resolution (fire-and-forget), but we await here to ensure completion
-    // Only needed when OTEL compat mode is enabled
-    if (
-      experiment &&
-      typeof process !== "undefined" &&
-      globalThis.BRAINTRUST_CONTEXT_MANAGER !== undefined
-    ) {
+    // Resolve the experiment ID before any task (and therefore any span) exists.
+    // Everything that reads the parent synchronously depends on it: OTEL parent
+    // attributes, and the `braintrust.parent` baggage entry that `Span.inject` /
+    // `injectTraceContext` emit. Without this, the first span of a run would
+    // propagate trace identity with no destination, and the receiving process
+    // would silently start a fresh local trace instead.
+    if (experiment) {
       await experiment._waitForId();
     }
 

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -8462,11 +8462,25 @@ export class SpanImpl implements Span {
   ): T | Record<string, string> {
     const resolvedCarrier = carrier ?? {};
     try {
+      const braintrustParent =
+        this._getOtelParent() ?? this._propagatedState?.braintrustParent;
+      if (!braintrustParent) {
+        // Symmetric with the receive-side warning in resolveW3cParent:
+        // surface this in the process that caused it, rather than leaving the
+        // consumer to debug a trace that arrived with no destination.
+        debugLogger
+          .forState(this._state)
+          .warn(
+            "Injecting trace context without a braintrust.parent; the receiver " +
+              "cannot route the trace and will start a fresh local span instead. " +
+              "The parent object id has not resolved yet (it resolves asynchronously " +
+              "after init); await the experiment or logger before injecting.",
+          );
+      }
       _injectIntoCarrier(resolvedCarrier, {
         traceId: this._rootSpanId,
         spanId: this._spanId,
-        braintrustParent:
-          this._getOtelParent() ?? this._propagatedState?.braintrustParent,
+        braintrustParent,
         propagatedState: this._propagatedState,
       });
     } catch (e) {

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -8471,10 +8471,9 @@ export class SpanImpl implements Span {
         debugLogger
           .forState(this._state)
           .warn(
-            "Injecting trace context without a braintrust.parent; the receiver " +
-              "cannot route the trace and will start a fresh local span instead. " +
-              "The parent object id has not resolved yet (it resolves asynchronously " +
-              "after init); await the experiment or logger before injecting.",
+            "Injecting trace context without braintrust.parent because the span's " +
+              "destination is not available yet. The receiver will start a new " +
+              "local trace instead of continuing this one.",
           );
       }
       _injectIntoCarrier(resolvedCarrier, {

--- a/js/src/propagation.test.ts
+++ b/js/src/propagation.test.ts
@@ -7,7 +7,7 @@
  * propagation path (no `@opentelemetry/api` dependency).
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   _exportsForTestingOnly,
   _injectIntoCarrier,
@@ -27,6 +27,10 @@ import {
   parseBaggage,
   parseTraceparent,
 } from "./propagation";
+import {
+  resetDebugLoggerForTests,
+  setGlobalDebugLogLevel,
+} from "./debug-logger";
 import { SpanComponentsV3 } from "../util/span_identifier_v3";
 import { SpanComponentsV4 } from "../util/span_identifier_v4";
 import { SpanObjectTypeV3 } from "../util/index";
@@ -476,6 +480,7 @@ test("getHeader reads Web Headers-style objects", () => {
 // --------------------------------------------------------------------------- //
 
 const PROJECT_NAME = "propagation-test";
+const EXPERIMENT_ID = "propagation-test-experiment";
 
 describe("inject / extract / round-trip", () => {
   let memoryLogger: ReturnType<
@@ -719,6 +724,47 @@ describe("inject / extract / round-trip", () => {
       expect(parseBaggage(carrier.values[BAGGAGE_HEADER])).toEqual({
         user: "alice",
         [BRAINTRUST_PARENT_KEY]: `project_name:${PROJECT_NAME}`,
+      });
+    });
+
+    // An experiment's id resolves asynchronously (POST /api/experiment/register),
+    // so a span created before it lands has no `braintrust.parent` to inject. The
+    // trace identity still propagates, which is how this used to fail silently:
+    // the receiver saw a traceparent it could not route and started a fresh local
+    // trace instead. Warn on the send side, where the problem actually is.
+    test("experiment span with an unresolved id warns and omits the parent", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      setGlobalDebugLogLevel("warn");
+      try {
+        const experiment =
+          _exportsForTestingOnly.initTestExperiment(EXPERIMENT_ID);
+        const span = experiment.startSpan({ name: "task" });
+        const carrier = span.inject<Record<string, string>>({});
+        span.end();
+
+        expect(carrier[TRACEPARENT_HEADER]).toMatch(TRACEPARENT_RE);
+        expect(BAGGAGE_HEADER in carrier).toBe(false);
+        expect(warnSpy).toHaveBeenCalledWith(
+          "[braintrust]",
+          expect.stringContaining("without a braintrust.parent"),
+        );
+      } finally {
+        resetDebugLoggerForTests();
+        warnSpy.mockRestore();
+      }
+    });
+
+    test("experiment span injects the parent once the id is resolved", async () => {
+      const experiment =
+        _exportsForTestingOnly.initTestExperiment(EXPERIMENT_ID);
+      await experiment._waitForId();
+
+      const span = experiment.startSpan({ name: "task" });
+      const carrier = span.inject<Record<string, string>>({});
+      span.end();
+
+      expect(parseBaggage(carrier[BAGGAGE_HEADER])).toEqual({
+        [BRAINTRUST_PARENT_KEY]: `experiment_id:${EXPERIMENT_ID}`,
       });
     });
 

--- a/js/src/propagation.test.ts
+++ b/js/src/propagation.test.ts
@@ -746,7 +746,7 @@ describe("inject / extract / round-trip", () => {
         expect(BAGGAGE_HEADER in carrier).toBe(false);
         expect(warnSpy).toHaveBeenCalledWith(
           "[braintrust]",
-          expect.stringContaining("without a braintrust.parent"),
+          expect.stringContaining("without braintrust.parent"),
         );
       } finally {
         resetDebugLoggerForTests();


### PR DESCRIPTION
## Problem

`Span.inject()` / `injectTraceContext()` are synchronous, but the experiment id they need is not. `_getOtelParent()` builds the `braintrust.parent` baggage entry from `parentObjectId.getSync()`, which stays `undefined` until `POST /api/experiment/register` returns. An inject that happens before then emits a `traceparent` with no `baggage`: trace identity with no destination.

The failure lands in a different process. The receiving side warns ("Received traceparent without a braintrust.parent ... Starting a fresh local span instead") and starts a fresh local trace, so spans from a subprocess agent land in project logs instead of the experiment. Discovery happens while debugging the consumer, not the producer. It is also first-span-only: the id caches once resolved, so it breaks the first turn of a run and then quietly stops, which is how it ships broken and goes unnoticed.

## Why this fixes it

The precondition belongs at experiment init, not in the injector, so the race becomes structurally impossible rather than narrower:

- `Eval()` already awaited `experiment._waitForId()`, but only when `globalThis.BRAINTRUST_CONTEXT_MANAGER !== undefined` (the opt-in `@braintrust/otel` integration). That gate was correct when written and stopped being correct once `inject` started depending on the same resolved id. Ungating it means no span can exist before the id does.
- `inject()` stays synchronous, matching the OTel propagator API, which is sync by spec.
- `SpanImpl.inject()` now warns when it has no `braintrust.parent`, symmetric with the receive-side warning. It does not prevent the failure, but it moves discovery to the process that caused it, which matters for the paths eager resolution does not cover.

| File | Change |
| --- | --- |
| `js/src/framework.ts` | Ungate `await experiment._waitForId()` in `Eval()` |
| `js/src/logger.ts` | Warn in `SpanImpl.inject()` when `braintrustParent` is empty |

## Testing

- `js/src/framework.test.ts`: `injectTraceContext()` inside the first `Eval()` task must carry `braintrust.parent`. Verified against the old gate, where it fails with `expected undefined to be 'experiment_id:experiment-id'` for every row, not just the first: concurrent tasks all inject before the first flush resolves the id.
- `js/src/propagation.test.ts`: unresolved experiment id warns and omits the parent; resolved id injects `experiment_id:<id>`.
- e2e `trace-context-and-continuation`, `trace-primitives-basic`, `test-framework-evals-node`, `otel-compat-mixed-tracing`, `durable-eval-webhook` pass, run twice.

## Notes

- Python is not affected. `_get_parent_info()` already falls back to a blocking `parent_object_id.get()` for experiments, and Python's `LazyValue.get()` computes on the calling thread, so a sync `inject()` there resolves the id rather than dropping it.
- Manual `init()` plus `startSpan()` plus inject is still racy, since `init()` is fully lazy and `lazyId` is not kicked off until the first flush. It now warns instead of failing silently. Closing it would mean either firing `lazyId.get()` from `Experiment.startSpan` (narrows the window, does not close it) or documenting `await experiment.id` before injecting.
