### PR TITLE
feat: Support audio input in prompt templates

### DIFF
--- a/.changeset/input-audio-prompt-content.md
+++ b/.changeset/input-audio-prompt-content.md
@@ -1,0 +1,5 @@
+---
+"braintrust": minor
+---
+
+feat: Support input audio content in prompt templates

--- a/generated_types.json
+++ b/generated_types.json
@@ -865,6 +865,9 @@
             "$ref": "#/components/schemas/ChatCompletionContentPartImageWithTitle"
           },
           {
+            "$ref": "#/components/schemas/ChatCompletionContentPartInputAudioWithTitle"
+          },
+          {
             "$ref": "#/components/schemas/ChatCompletionContentPartFileWithTitle"
           }
         ],
@@ -965,6 +968,44 @@
         },
         "required": ["image_url", "type"],
         "title": "image_url"
+      },
+      "ChatCompletionContentPartInputAudioWithTitle": {
+        "type": "object",
+        "properties": {
+          "input_audio": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "string"
+              },
+              "format": {
+                "type": "string",
+                "enum": ["wav", "mp3"]
+              }
+            },
+            "required": ["data", "format"]
+          },
+          "type": {
+            "type": "string",
+            "enum": ["input_audio"]
+          },
+          "cache_control": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["ephemeral"]
+              },
+              "ttl": {
+                "type": "string",
+                "enum": ["5m", "1h"]
+              }
+            },
+            "required": ["type"]
+          }
+        },
+        "required": ["input_audio", "type"],
+        "title": "input_audio"
       },
       "ChatCompletionContentPartText": {
         "type": "object",

--- a/js/src/generated_plain_types.ts
+++ b/js/src/generated_plain_types.ts
@@ -1,4 +1,4 @@
-// Auto-generated file (content hash 719572142fc24803) -- do not modify
+// Auto-generated file (content hash 48f2c828cb95730e) -- do not modify
 
 export type AclObjectTypeType =
   /**
@@ -1040,6 +1040,33 @@ export type ChatCompletionContentPartImageWithTitleType = {
       }
     | undefined;
 };
+export type ChatCompletionContentPartInputAudioWithTitleType = {
+  input_audio: {
+    data: string;
+    /**
+     * @enum wav, mp3
+     */
+    format: "wav" | "mp3";
+  };
+  /**
+   * @enum input_audio
+   */
+  type: "input_audio";
+  cache_control?:
+    | {
+        /**
+         * @enum ephemeral
+         */
+        type: "ephemeral";
+        ttl?:
+          | /**
+           * @enum 5m, 1h
+           */
+          ("5m" | "1h")
+          | undefined;
+      }
+    | undefined;
+};
 export type ChatCompletionContentPartFileFileType = Partial<{
   file_data: string;
   filename: string;
@@ -1069,6 +1096,7 @@ export type ChatCompletionContentPartFileWithTitleType = {
 export type ChatCompletionContentPartType =
   | ChatCompletionContentPartTextWithTitleType
   | ChatCompletionContentPartImageWithTitleType
+  | ChatCompletionContentPartInputAudioWithTitleType
   | ChatCompletionContentPartFileWithTitleType;
 export type ChatCompletionContentPartTextType = {
   /**

--- a/js/src/generated_types.ts
+++ b/js/src/generated_types.ts
@@ -1,4 +1,4 @@
-// Auto-generated file (content hash 719572142fc24803) -- do not modify
+// Auto-generated file (content hash 48f2c828cb95730e) -- do not modify
 
 import { z } from "zod/v3";
 
@@ -424,6 +424,19 @@ export const ChatCompletionContentPartImageWithTitle = z.object({
 export type ChatCompletionContentPartImageWithTitleType = z.infer<
   typeof ChatCompletionContentPartImageWithTitle
 >;
+export const ChatCompletionContentPartInputAudioWithTitle = z.object({
+  input_audio: z.object({ data: z.string(), format: z.enum(["wav", "mp3"]) }),
+  type: z.literal("input_audio"),
+  cache_control: z
+    .object({
+      type: z.literal("ephemeral"),
+      ttl: z.enum(["5m", "1h"]).optional(),
+    })
+    .optional(),
+});
+export type ChatCompletionContentPartInputAudioWithTitleType = z.infer<
+  typeof ChatCompletionContentPartInputAudioWithTitle
+>;
 export const ChatCompletionContentPartFileFile = z
   .object({ file_data: z.string(), filename: z.string(), file_id: z.string() })
   .partial();
@@ -446,6 +459,7 @@ export type ChatCompletionContentPartFileWithTitleType = z.infer<
 export const ChatCompletionContentPart = z.union([
   ChatCompletionContentPartTextWithTitle,
   ChatCompletionContentPartImageWithTitle,
+  ChatCompletionContentPartInputAudioWithTitle,
   ChatCompletionContentPartFileWithTitle,
 ]);
 export type ChatCompletionContentPartType = z.infer<

--- a/js/src/logger.test.ts
+++ b/js/src/logger.test.ts
@@ -44,7 +44,7 @@ import { LRUCache } from "./lru-cache";
 
 configureNode();
 
-test("renderMessage with file content parts", () => {
+test("renderMessage renders templates in structured content parts", () => {
   const message = {
     role: "user" as const,
     content: [
@@ -56,6 +56,13 @@ test("renderMessage with file content parts", () => {
         type: "image_url" as const,
         image_url: {
           url: "{{image_url}}",
+        },
+      },
+      {
+        type: "input_audio" as const,
+        input_audio: {
+          data: "{{audio_data}}",
+          format: "wav" as const,
         },
       },
       {
@@ -72,6 +79,7 @@ test("renderMessage with file content parts", () => {
   const variables = {
     item: "document",
     image_url: "https://example.com/image.png",
+    audio_data: "base64audio",
     file_data: "base64data",
     file_id: "file-456",
     filename: "report.pdf",
@@ -82,6 +90,7 @@ test("renderMessage with file content parts", () => {
       template
         .replace("{{item}}", "document")
         .replace("{{image_url}}", "https://example.com/image.png")
+        .replace("{{audio_data}}", "base64audio")
         .replace("{{file_data}}", "base64data")
         .replace("{{file_id}}", "file-456")
         .replace("{{filename}}", "report.pdf"),
@@ -98,6 +107,13 @@ test("renderMessage with file content parts", () => {
       type: "image_url",
       image_url: {
         url: "https://example.com/image.png",
+      },
+    },
+    {
+      type: "input_audio",
+      input_audio: {
+        data: "base64audio",
+        format: "wav",
       },
     },
     {

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -9324,6 +9324,16 @@ export function renderMessageImpl<T extends Message>(
                           },
                         },
                       ];
+                    case "input_audio":
+                      return [
+                        {
+                          ...c,
+                          input_audio: {
+                            ...c.input_audio,
+                            data: render(c.input_audio.data),
+                          },
+                        },
+                      ];
                     case "file":
                       return [
                         {

--- a/js/util/generated_plain_types.ts
+++ b/js/util/generated_plain_types.ts
@@ -1,4 +1,4 @@
-// Auto-generated file (content hash 719572142fc24803) -- do not modify
+// Auto-generated file (content hash 48f2c828cb95730e) -- do not modify
 
 export type AclObjectTypeType =
   /**
@@ -1040,6 +1040,33 @@ export type ChatCompletionContentPartImageWithTitleType = {
       }
     | undefined;
 };
+export type ChatCompletionContentPartInputAudioWithTitleType = {
+  input_audio: {
+    data: string;
+    /**
+     * @enum wav, mp3
+     */
+    format: "wav" | "mp3";
+  };
+  /**
+   * @enum input_audio
+   */
+  type: "input_audio";
+  cache_control?:
+    | {
+        /**
+         * @enum ephemeral
+         */
+        type: "ephemeral";
+        ttl?:
+          | /**
+           * @enum 5m, 1h
+           */
+          ("5m" | "1h")
+          | undefined;
+      }
+    | undefined;
+};
 export type ChatCompletionContentPartFileFileType = Partial<{
   file_data: string;
   filename: string;
@@ -1069,6 +1096,7 @@ export type ChatCompletionContentPartFileWithTitleType = {
 export type ChatCompletionContentPartType =
   | ChatCompletionContentPartTextWithTitleType
   | ChatCompletionContentPartImageWithTitleType
+  | ChatCompletionContentPartInputAudioWithTitleType
   | ChatCompletionContentPartFileWithTitleType;
 export type ChatCompletionContentPartTextType = {
   /**

--- a/js/util/generated_types.ts
+++ b/js/util/generated_types.ts
@@ -1,4 +1,4 @@
-// Auto-generated file (content hash 719572142fc24803) -- do not modify
+// Auto-generated file (content hash 48f2c828cb95730e) -- do not modify
 
 import { z } from "zod/v3";
 
@@ -424,6 +424,19 @@ export const ChatCompletionContentPartImageWithTitle = z.object({
 export type ChatCompletionContentPartImageWithTitleType = z.infer<
   typeof ChatCompletionContentPartImageWithTitle
 >;
+export const ChatCompletionContentPartInputAudioWithTitle = z.object({
+  input_audio: z.object({ data: z.string(), format: z.enum(["wav", "mp3"]) }),
+  type: z.literal("input_audio"),
+  cache_control: z
+    .object({
+      type: z.literal("ephemeral"),
+      ttl: z.enum(["5m", "1h"]).optional(),
+    })
+    .optional(),
+});
+export type ChatCompletionContentPartInputAudioWithTitleType = z.infer<
+  typeof ChatCompletionContentPartInputAudioWithTitle
+>;
 export const ChatCompletionContentPartFileFile = z
   .object({ file_data: z.string(), filename: z.string(), file_id: z.string() })
   .partial();
@@ -446,6 +459,7 @@ export type ChatCompletionContentPartFileWithTitleType = z.infer<
 export const ChatCompletionContentPart = z.union([
   ChatCompletionContentPartTextWithTitle,
   ChatCompletionContentPartImageWithTitle,
+  ChatCompletionContentPartInputAudioWithTitle,
   ChatCompletionContentPartFileWithTitle,
 ]);
 export type ChatCompletionContentPartType = z.infer<


### PR DESCRIPTION
OpenAI’s Chat API documents input_audio.data as base64 audio and limits format to wav or mp3. OpenAI Chat API reference (https://platform.openai.com/docs/api-reference/chat/create)

extending the SDK so we can async score audio files in main repo