### PR TITLE
Strip review assignment metadata from eval rows

### DIFF
--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -212,6 +212,7 @@ describe("runEvaluator", () => {
     datum: {
       input: number;
       id: string;
+      metadata?: Record<string, unknown>;
       _xact_id?: string;
       created?: string;
       origin?: {
@@ -307,6 +308,41 @@ describe("runEvaluator", () => {
       _xact_id: "dataset-xact",
       created: "2026-06-02T00:00:00.000Z",
     });
+  });
+
+  test("strips review assignment metadata from dataset-backed eval rows", async () => {
+    const data = makeDatasetData("00000000-0000-0000-0000-000000000001", {
+      input: 1,
+      id: "dataset-row-1",
+      metadata: {
+        keep: "yes",
+        "~__bt_assignments": ["user-id"],
+        "~__bt_review_lists": {
+          __bt_default_review_list: { status: "PENDING" },
+        },
+      },
+    });
+    let taskMetadata: Record<string, unknown> | null = null;
+
+    const out = await runEvaluator(
+      null,
+      {
+        projectName: "proj",
+        evalName: "eval",
+        data,
+        task: async (input: number, { metadata }) => {
+          taskMetadata = { ...metadata };
+          return input * 2;
+        },
+        scores: [],
+      },
+      new NoopProgressReporter(),
+      [],
+      undefined,
+    );
+
+    expect(taskMetadata).toEqual({ keep: "yes" });
+    expect(out.results[0].metadata).toEqual({ keep: "yes" });
   });
 
   test("falls back to source origin when dataset row origin is incomplete", async () => {

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -975,6 +975,24 @@ export function classifierName(
   return classifier.name || `classifier_${classifier_idx}`;
 }
 
+const REVIEW_ASSIGNMENT_METADATA_KEYS = new Set([
+  "~__bt_assignments",
+  "~__bt_review_lists",
+]);
+
+function stripReviewAssignmentMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (metadata === undefined) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(metadata).filter(
+      ([key]) => !REVIEW_ASSIGNMENT_METADATA_KEYS.has(key),
+    ),
+  );
+}
+
 export async function _internalRunEvaluatorTask(
   task: EvalTask<any, any, any, any, any>,
   datum: EvalCase<any, any, any>,
@@ -987,9 +1005,9 @@ export async function _internalRunEvaluatorTask(
   metadata: Record<string, unknown>;
   tags: string[];
 }> {
-  const metadata: Record<string, unknown> = {
-    ...("metadata" in datum ? datum.metadata : {}),
-  };
+  const metadata = stripReviewAssignmentMetadata(
+    "metadata" in datum ? datum.metadata : undefined,
+  );
   const hooks: EvalHooks<unknown, Record<string, unknown>, EvalParameters> = {
     meta(value) {
       Object.assign(metadata, value);


### PR DESCRIPTION
## Summary

  - Strip Braintrust-owned review assignment metadata when initializing eval task metadata
  - Preserve normal user metadata and existing hook mutation behavior
  - Add regression coverage for dataset-backed eval rows

  ## Testing

  - `pnpm exec vitest run src/framework.test.ts -t "strips review assignment metadata"`
  - `pnpm exec prettier --write js/src/framework.ts js/src/framework.test.ts`

Addresses Linear COR-85