### PR TITLE
fix: Prevent eval trial upsert collisions

### DIFF
--- a/.changeset/remote-eval-trial-upsert-ids.md
+++ b/.changeset/remote-eval-trial-upsert-ids.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+Prevent evaluation trials from overwriting each other when an upsert ID is supplied, while preserving stable per-trial IDs across reruns.

--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -7,6 +7,7 @@ import {
   afterEach,
   vi,
 } from "vitest";
+import { type ExperimentEvent } from "../util";
 import {
   defaultErrorScoreHandler,
   Eval,
@@ -21,6 +22,7 @@ import {
   initLogger,
   injectTraceContext,
   TestBackgroundLogger,
+  withParent,
 } from "./logger";
 import { parseBaggage } from "./propagation";
 import { configureNode } from "./node/config";
@@ -794,6 +796,95 @@ test("trialIndex is passed to task", async () => {
     expect(result.error).toBeUndefined();
   });
 });
+
+describe.each([false, true])(
+  "trial upsert IDs with parent context: %s",
+  (useParent) => {
+    test.each(
+      ["eval-row", undefined, ""].flatMap((upsertId) =>
+        [
+          { trialCount: 1, rowTrialCount: undefined },
+          { trialCount: 3, rowTrialCount: undefined },
+          { trialCount: 1, rowTrialCount: 3 },
+          { trialCount: 3, rowTrialCount: 1 },
+        ].map((counts) => ({ upsertId, ...counts })),
+      ),
+    )(
+      "preserves separate trial rows across reruns: %j",
+      async ({ upsertId, trialCount, rowTrialCount }) => {
+        await _exportsForTestingOnly.simulateLoginForTests();
+        const memoryLogger = _exportsForTestingOnly.useTestBackgroundLogger();
+        const experiment =
+          _exportsForTestingOnly.initTestExperiment("trial-upsert");
+        const parent = await experiment.export();
+        const count = rowTrialCount ?? trialCount;
+        let previousIds: string[] = [];
+
+        for (const input of [1, 2]) {
+          await withParent(parent, () =>
+            runEvaluator(
+              useParent ? null : experiment,
+              {
+                projectName: "proj",
+                evalName: "trial-upsert",
+                state: experiment.loggingState,
+                data: [
+                  { input, upsert_id: upsertId, trialCount: rowTrialCount },
+                ],
+                task: (value, { trialIndex }) => value * 10 + trialIndex,
+                scores: [],
+                trialCount,
+                summarizeScores: false,
+              },
+              new NoopProgressReporter(),
+              [],
+              undefined,
+              undefined,
+              true,
+            ),
+          );
+
+          await memoryLogger.flush();
+          const spans = (await memoryLogger.drain()).filter(
+            (log): log is ExperimentEvent =>
+              "experiment_id" in log && "span_id" in log,
+          );
+          const roots = spans
+            .filter((span) => !span.span_parents?.length)
+            .sort((a, b) => Number(a.output) - Number(b.output));
+          expect(roots).toHaveLength(count);
+          expect(spans).toHaveLength(count * 2);
+          for (const [trialIndex, root] of roots.entries()) {
+            expect(root.output).toBe(input * 10 + trialIndex);
+            const children = spans.filter(
+              (span) => span.span_parents?.[0] === root.span_id,
+            );
+            expect(children).toHaveLength(1);
+            expect(children[0].output).toEqual(root.output);
+          }
+
+          const ids = roots.map((root) => root.id);
+          expect(new Set(ids).size).toBe(count);
+          if (upsertId) {
+            expect(ids).toEqual(
+              [
+                upsertId,
+                "0a452074-8534-5d0a-a418-8dc075187dd6",
+                "1df30387-03bd-5d6a-a651-d80f0b576e6e",
+              ].slice(0, count),
+            );
+            if (previousIds.length) {
+              expect(ids).toEqual(previousIds);
+            }
+          } else {
+            expect(ids.some((id) => previousIds.includes(id))).toBe(false);
+          }
+          previousIds = ids;
+        }
+      },
+    );
+  },
+);
 
 test("trialIndex with multiple inputs", async () => {
   const trialData: Array<{ input: number; trialIndex: number }> = [];

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -16,6 +16,7 @@ import {
   type SSEProgressEventDataType as SSEProgressEventData,
 } from "./generated_types";
 import { queue } from "async";
+import { v5 as uuidv5 } from "uuid";
 
 import iso from "./isomorph";
 import { debugLogger } from "./debug-logger";
@@ -1328,6 +1329,13 @@ async function runEvaluatorInternal(
         const origin =
           inlineDatasetOrigin ??
           (parsedDatumOrigin?.success ? parsedDatumOrigin.data : undefined);
+        const upsertId =
+          datum.upsert_id && trialIndex > 0
+            ? uuidv5(
+                `braintrust:eval:${datum.upsert_id}:trial:${trialIndex}`,
+                uuidv5.URL,
+              )
+            : datum.upsert_id;
 
         const baseEvent: StartSpanArgs = {
           name: "eval",
@@ -1339,7 +1347,7 @@ async function runEvaluatorInternal(
             expected: "expected" in datum ? datum.expected : undefined,
             tags: datum.tags,
             origin,
-            ...(datum.upsert_id ? { id: datum.upsert_id } : {}),
+            ...(upsertId ? { id: upsertId } : {}),
           },
         };
 


### PR DESCRIPTION
### Why

Related to [COR-84](https://linear.app/braintrustdata/issue/COR-84/remote-eval-playground-re-running-a-row-leaves-a-duplicate-grid-row). Addresses the JS counterpart of the [P1 raised on the Python SDK fix](https://github.com/braintrustdata/braintrust-sdk-python/pull/763#discussion_r3993461024).

The intent is to keep one independently updatable result per evaluation trial. The JS SDK already preserves `upsert_id`, but currently reuses that exact record ID for every trial. With multiple trials, their root records overwrite each other, losing trial results and potentially leaving task spans attached to the wrong surviving root. Generating fresh random IDs would avoid collisions but break rerun upserts.

This fixes an existing JS multi-trial bug, not Python's original dropped-`upsert_id` bug. It matches the per-trial ID scheme in [braintrust-sdk-python#763](https://github.com/braintrustdata/braintrust-sdk-python/pull/763).

### Repro

1. Run an evaluator with a row containing `upsert_id: "eval-row"` and `trialCount: 3`, with a task returning a different output for each trial index.
2. Inspect the logged records after row merging: only one root record remains instead of three because all trials use `id: "eval-row"`.
3. Rerun with the same upsert ID: the trials collide again instead of each updating their own result.

The regression reproduces this for both experiment-backed and remote-parent execution, and with global or per-row trial counts. Before the fix, four multi-trial cases fail with one logged root instead of three; the other 20 cases pass. Two remote eval columns are not required to trigger this P1.

### Fix

- Keep the original `upsert_id` for trial zero, preserving single-trial behavior.
- For later trials, derive a deterministic UUID v5 in the URL namespace from `braintrust:eval:<upsert_id>:trial:<trial_index>`. Each trial has a distinct ID that stays stable on rerun, matching Python.
- Leave missing/empty upsert IDs on the existing fresh-ID path. Do not change dataset origins, trial scheduling, or public APIs; reuse the existing UUID dependency.
- Include the required patch changeset for `braintrust`.

The behavior change is limited to additional trials with a non-empty upsert ID. This prevents future trial collisions after upgrading; it does not restore overwritten results or clean up historical records.

### Test

- `pnpm test src/framework.test.ts --reporter=dot`: all 104 tests pass, including 24 regression cases covering supplied/missing/empty IDs, global/per-row trial counts, and experiment/parent-context execution.
- Regression assertions check separate roots, matching root/task outputs, stable IDs across reruns, and UUID values matching Python's implementation.
- `pnpm run check:typings`: passes for production and test code.
- Targeted ESLint: no errors; existing warnings remain and the repository config excludes test files.
- `pnpm run fix:formatting` and `git diff --check`: pass.
